### PR TITLE
fix: command palette navigation and reduce window height

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,37 +1,15 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { Routes, Route, Navigate, useNavigate } from 'react-router-dom';
 import { Events } from '@wailsio/runtime';
+
 import { Sidebar } from './components/Sidebar';
 import { TitleBar } from './components/TitleBar';
 import { SettingsModal } from './components/SettingsModal';
 import ToolRouter from './ToolRouter';
 import './App.css';
 
-// NavigationHandler listens for navigate events from command palette
-function NavigationHandler() {
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    console.log('[App] Setting up navigation event listener...');
-
-    // Listen for navigation events from command palette (via Go backend)
-    const unsubscribe = Events.On('navigate:to', (path) => {
-      console.log('[App] Received navigate:to event:', path);
-      if (path) {
-        navigate(path);
-      }
-    });
-
-    return () => {
-      console.log('[App] Cleaning up navigation event listener');
-      if (unsubscribe) unsubscribe();
-    };
-  }, [navigate]);
-
-  return null;
-}
-
 function App() {
+  const navigate = useNavigate();
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [themeMode, setThemeMode] = useState(() => {
@@ -42,8 +20,50 @@ function App() {
   const openSettings = () => setIsSettingsOpen(true);
   const closeSettings = () => setIsSettingsOpen(false);
 
-  // Global spotlight shortcut is Cmd+Shift+Space (handled by Go backend)
+  // Handle navigation events from command palette
+  useEffect(() => {
+    console.log('[App] Setting up navigation listener for command palette...');
 
+    const handleNavigation = (data) => {
+      console.log('[App] Received navigate:to event:', data);
+
+      // In Wails V3, data might be the path string OR an event object with path in data
+      let path = '';
+      if (typeof data === 'string') {
+        path = data;
+      } else if (data && typeof data === 'object') {
+        if (data.data) {
+          path = typeof data.data === 'string' ? data.data : data.data[0];
+        } else if (data.path) {
+          path = data.path;
+        }
+      }
+
+      if (path) {
+        console.log('[App] Navigating to path:', path);
+        navigate(path);
+      } else {
+        console.warn('[App] Received empty/invalid path via navigate:to:', data);
+      }
+    };
+
+    let unsubscribe = null;
+    try {
+      unsubscribe = Events.On('navigate:to', (event) => {
+        handleNavigation(event);
+      });
+      console.log('[App] Navigation listener registered successfully');
+    } catch (err) {
+      console.error('[App] Failed to register navigation listener:', err);
+    }
+
+    return () => {
+      console.log('[App] Cleaning up navigation listener');
+      if (unsubscribe) unsubscribe();
+    };
+  }, [navigate]);
+
+  // Handle theme changes
   useEffect(() => {
     localStorage.setItem('themeMode', themeMode);
     if (themeMode === 'dark') {
@@ -90,7 +110,6 @@ function App() {
             <Route path="/tool/:toolId/*" element={<ToolRouter />} />
             <Route path="*" element={<Navigate to="/tool/text-converter" replace />} />
           </Routes>
-          <NavigationHandler />
         </main>
       </div>
 

--- a/frontend/src/components/CommandPalette.css
+++ b/frontend/src/components/CommandPalette.css
@@ -59,7 +59,7 @@
 }
 
 .command-palette-results {
-  height: 332px; /* Reduced to ~80% of original (416 * 0.8) */
+  height: 264px; /* Results area: 80% of original (332 * 0.8) */
   overflow: hidden;
   background: #18181b;
 }
@@ -73,7 +73,7 @@
 
 .command-palette-list {
   overflow-y: auto;
-  max-height: 320px; /* Reduced to match results height */
+  max-height: 252px; /* 80% of original (320 * 0.8) */
 }
 
 .command-palette-item {

--- a/main.go
+++ b/main.go
@@ -160,9 +160,9 @@ func main() {
 	spotlightWindow := app.Window.NewWithOptions(application.WebviewWindowOptions{
 		Title:            "Spotlight",
 		Width:            640,
-		Height:           480,
-		MinHeight:        480,
-		MaxHeight:        480,
+		Height:           384,
+		MinHeight:        384,
+		MaxHeight:        384,
 		Frameless:        true,
 		Hidden:           true,
 		BackgroundColour: application.RGBA{Red: 22, Green: 22, Blue: 22, Alpha: 255},


### PR DESCRIPTION
## Summary
- Fix command palette navigation by moving listener from NavigationHandler component directly into App component
- Use Events.On from @wailsio/runtime for proper event handling between Go backend and React frontend
- Reduce command palette window height to 80% (480px → 384px) for better UX
- Adjust CSS heights for results area (332px → 264px) and list (320px → 252px) to match

## Test Plan
- [x] Open command palette with Cmd+Shift+Space
- [x] Select a tool and verify navigation works
- [x] Verify window height is reduced by ~20%
- [x] Run Go tests: go test ./...