### PR TITLE
Fix editor-backed tool E2E flows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Cache APT packages
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: libgtk-3-dev libwebkit2gtk-4.1-dev
+          packages: libgtk-4-dev libwebkitgtk-6.0-dev
           version: 1.0
           execute_install_scripts: false
 
@@ -133,7 +133,7 @@ jobs:
       - name: Install system deps (Wails CGO)
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
+          sudo apt-get install -y libgtk-4-dev libwebkitgtk-6.0-dev
 
       - name: Run govulncheck
         run: |
@@ -162,7 +162,7 @@ jobs:
       - name: Cache APT packages
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: libgtk-3-dev libwebkit2gtk-4.1-dev
+          packages: libgtk-4-dev libwebkitgtk-6.0-dev
           version: 1.0
           execute_install_scripts: false
 
@@ -192,4 +192,3 @@ jobs:
       - name: Run frontend tests
         run: |
           cd frontend && bun run test
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
+          sudo apt-get install -y libgtk-4-dev libwebkitgtk-6.0-dev
 
       - name: Install Task
         uses: arduino/setup-task@v2

--- a/frontend/e2e/barcodeGenerator.spec.js
+++ b/frontend/e2e/barcodeGenerator.spec.js
@@ -6,7 +6,7 @@ test.describe('Barcode / QR Code Generator', () => {
   });
 
   test('should load with QR Code type selected', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: 'Barcode / QR Code' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /Barcode \/ QR Code/ })).toBeVisible();
     await expect(page.getByText('Generate high-quality QR codes and barcodes')).toBeVisible();
     // QR type should be active
     await expect(page.getByRole('button', { name: 'QR Code' })).toBeVisible();
@@ -77,15 +77,10 @@ test.describe('Barcode / QR Code Generator', () => {
   });
 
   test('should toggle layout orientation', async ({ page }) => {
-    // Layout toggle button should exist (Columns icon)
-    const layoutButton = page
-      .locator('button')
-      .filter({ has: page.locator('svg') })
-      .filter({ hasNotText: /Clear|PNG|SVG|QR|Code|EAN/ })
-      .first();
+    const layoutButton = page.getByRole('button', { name: 'Toggle layout orientation' });
     await layoutButton.click();
     // After toggle, the layout should be vertical (single column grid)
     // Just verify the button is clickable and no error occurs
-    await expect(page.getByRole('heading', { name: 'Barcode / QR Code' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /Barcode \/ QR Code/ })).toBeVisible();
   });
 });

--- a/frontend/e2e/codeConverter.spec.js
+++ b/frontend/e2e/codeConverter.spec.js
@@ -1,4 +1,11 @@
 import { test, expect } from '@playwright/test';
+import {
+  fillEditor,
+  readEditorText,
+  expectEditorText,
+  expectEditorContains,
+  expectEditorNotEmpty,
+} from './helpers/editor';
 
 test.describe('Code Converter', () => {
   test.beforeEach(async ({ page }) => {
@@ -9,142 +16,104 @@ test.describe('Code Converter', () => {
   test('loads with default method JSON ↔ YAML', async ({ page }) => {
     const select = page.locator('select');
     await expect(select).toHaveValue('JSON ↔ YAML');
-    await expect(page.locator('textarea')).toHaveCount(2);
+    await expect(page.getByTestId('code-converter-input')).toBeVisible();
+    await expect(page.getByTestId('code-converter-output')).toBeVisible();
   });
 
   test('converts JSON to YAML', async ({ page }) => {
-    const input = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
-
-    await input.fill('{"name": "test", "value": 42}');
-    await expect(output).toHaveValue(/name:\s*test/);
-    await expect(output).toHaveValue(/value:\s*42/);
+    await fillEditor(page, 'code-converter-input', '{"name": "test", "value": 42}');
+    await expectEditorContains(page, 'code-converter-output', /name:\s*test/);
+    await expectEditorContains(page, 'code-converter-output', /value:\s*42/);
   });
 
   test('converts YAML to JSON', async ({ page }) => {
-    const input = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
-
-    await input.fill('name: hello\nitems:\n  - a\n  - b');
-    await expect(output).toHaveValue(/\"name\":\s*\"hello\"/);
+    await fillEditor(page, 'code-converter-input', 'name: hello\nitems:\n  - a\n  - b');
+    await expectEditorContains(page, 'code-converter-output', /"name":\s*"hello"/);
   });
 
   test('converts JSON to XML', async ({ page }) => {
     await page.locator('select').selectOption('JSON ↔ XML');
-    const input = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
-
-    await input.fill('{"hello": "world"}');
-    await expect(output).toHaveValue(/<hello>/);
-    await expect(output).toHaveValue(/world/);
+    await fillEditor(page, 'code-converter-input', '{"hello": "world"}');
+    await expectEditorContains(page, 'code-converter-output', /<hello>/);
+    await expectEditorContains(page, 'code-converter-output', /world/);
   });
 
   test('converts XML to JSON', async ({ page }) => {
     await page.locator('select').selectOption('JSON ↔ XML');
-    const input = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
-
-    await input.fill('<root><name>test</name></root>');
-    await expect(output).toHaveValue(/\"name\"/);
+    await fillEditor(page, 'code-converter-input', '<root><name>test</name></root>');
+    await expectEditorContains(page, 'code-converter-output', /"name"/);
   });
 
   test('case swapping', async ({ page }) => {
     await page.locator('select').selectOption('Case Swapping');
-    const input = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
-
-    await input.fill('Hello World');
-    await expect(output).toHaveValue('hELLO wORLD');
+    await fillEditor(page, 'code-converter-input', 'Hello World');
+    await expectEditorText(page, 'code-converter-output', 'hELLO wORLD');
   });
 
   test('converts CSV to JSON', async ({ page }) => {
     await page.locator('select').selectOption('JSON ↔ CSV / TSV');
-    const input = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
-
-    await input.fill('name,age\nAlice,30\nBob,25');
-    await expect(output).toHaveValue(/\"name\":\s*\"Alice\"/);
-    await expect(output).toHaveValue(/\"age\":\s*\"30\"/);
+    await fillEditor(page, 'code-converter-input', 'name,age\nAlice,30\nBob,25');
+    await expectEditorContains(page, 'code-converter-output', /"name":\s*"Alice"/);
+    await expectEditorContains(page, 'code-converter-output', /"age":\s*"30"/);
   });
 
   test('converts CSV to TSV', async ({ page }) => {
     await page.locator('select').selectOption('CSV ↔ TSV');
-    const input = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
-
-    await input.fill('name,age\nAlice,30');
-    await expect(output).toHaveValue(/name\tage/);
+    await fillEditor(page, 'code-converter-input', 'name,age\nAlice,30');
+    await expectEditorContains(page, 'code-converter-output', /name\tage/);
   });
 
   test('converts Key-Value to Query String', async ({ page }) => {
     await page.locator('select').selectOption('Key-Value ↔ Query String');
-    const input = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
-
-    await input.fill('foo=bar\nbaz=qux');
-    await expect(output).not.toHaveValue('');
-    const value = await output.inputValue();
+    await fillEditor(page, 'code-converter-input', 'foo=bar\nbaz=qux');
+    await expectEditorNotEmpty(page, 'code-converter-output');
+    const value = await readEditorText(page, 'code-converter-output');
     expect(value).toContain('baz=qux');
     expect(value).toContain('foo=bar');
   });
 
   test('converts Properties to JSON', async ({ page }) => {
     await page.locator('select').selectOption('Properties ↔ JSON');
-    const input = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
-
-    await input.fill('app.name=MyApp\napp.version=1.0');
-    await expect(output).toHaveValue(/\"app.name\":\s*\"MyApp\"/);
+    await fillEditor(page, 'code-converter-input', 'app.name=MyApp\napp.version=1.0');
+    await expectEditorContains(page, 'code-converter-output', /"app.name":\s*"MyApp"/);
   });
 
   test('converts INI to JSON', async ({ page }) => {
     await page.locator('select').selectOption('INI ↔ JSON');
-    const input = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
-
-    await input.fill('[section]\nkey=value');
-    await expect(output).toHaveValue(/\"section\"/);
-    await expect(output).toHaveValue(/\"key\":\s*\"value\"/);
+    await fillEditor(page, 'code-converter-input', '[section]\nkey=value');
+    await expectEditorContains(page, 'code-converter-output', /"section"/);
+    await expectEditorContains(page, 'code-converter-output', /"key":\s*"value"/);
   });
 
   test('converts curl to fetch', async ({ page }) => {
     await page.locator('select').selectOption('CURL ↔ Fetch');
-    const input = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
-
-    await input.fill(
+    await fillEditor(
+      page,
+      'code-converter-input',
       'curl -X POST https://api.example.com/data -H \'Content-Type: application/json\' -d \'{"key":"value"}\''
     );
-    await expect(output).toHaveValue(/fetch\(/);
-    await expect(output).toHaveValue(/method:\s*'POST'/);
+    await expectEditorContains(page, 'code-converter-output', /fetch\(/);
+    await expectEditorContains(page, 'code-converter-output', /method:\s*'POST'/);
   });
 
   test('converts cron expression to text', async ({ page }) => {
     await page.locator('select').selectOption('Cron ↔ Text');
-    const input = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
-
-    await input.fill('0 9 * * 1');
-    await expect(output).toHaveValue(/Monday/);
+    await fillEditor(page, 'code-converter-input', '0 9 * * 1');
+    await expectEditorContains(page, 'code-converter-output', /Monday/);
   });
 
   test('shows error for invalid JSON with YAML method', async ({ page }) => {
-    const input = page.locator('textarea').first();
-    await input.fill('not valid json');
+    await fillEditor(page, 'code-converter-input', 'not valid json');
     // Error should appear in the output pane (border turns red)
-    const outputPane = page.locator('textarea').nth(1);
-    await expect(outputPane).toHaveValue('');
+    await expectEditorText(page, 'code-converter-output', '');
   });
 
   test('clears output when input is cleared', async ({ page }) => {
-    const input = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
+    await fillEditor(page, 'code-converter-input', '{"test": true}');
+    await expectEditorNotEmpty(page, 'code-converter-output');
 
-    await input.fill('{"test": true}');
-    await expect(output).not.toHaveValue('');
-
-    await input.fill('');
-    await expect(output).toHaveValue('');
+    await fillEditor(page, 'code-converter-input', '');
+    await expectEditorText(page, 'code-converter-output', '');
   });
 
   test('layout toggle switches between horizontal and vertical', async ({ page }) => {
@@ -169,8 +138,7 @@ test.describe('Code Converter', () => {
   test('copy button copies output to clipboard', async ({ page, context }) => {
     await context.grantPermissions(['clipboard-read', 'clipboard-write']);
 
-    const input = page.locator('textarea').first();
-    await input.fill('{"copied": true}');
+    await fillEditor(page, 'code-converter-input', '{"copied": true}');
 
     const copyButton = page.locator('button[title="Copy to clipboard"]').first();
     await copyButton.click();

--- a/frontend/e2e/codeEncoder.spec.js
+++ b/frontend/e2e/codeEncoder.spec.js
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { fillEditor, expectEditorText, expectEditorNotEmpty } from './helpers/editor';
 
 test.describe('Code Encoder', () => {
   test.beforeEach(async ({ page }) => {
@@ -8,84 +9,60 @@ test.describe('Code Encoder', () => {
 
   test('loads with default method Base64 and Encode mode', async ({ page }) => {
     await expect(page.locator('select')).toHaveValue('Base64');
-    await expect(page.locator('button').filter({ hasText: 'Encode' })).toHaveCSS(
-      'background-color',
-      'rgb(39, 39, 42)'
+    await expect(page.locator('button').filter({ hasText: 'Encode' })).toHaveAttribute(
+      'style',
+      /background-color: var\(--border\)/
     );
   });
 
   test('encodes text to Base64', async ({ page }) => {
-    const input = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
-
-    await input.fill('hello');
-    await expect(output).toHaveValue('aGVsbG8=');
+    await fillEditor(page, 'code-encoder-input', 'hello');
+    await expectEditorText(page, 'code-encoder-output', 'aGVsbG8=');
   });
 
   test('decodes Base64 to text', async ({ page }) => {
-    const input = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
-
-    await input.fill('aGVsbG8gd29ybGQ=');
+    await fillEditor(page, 'code-encoder-input', 'aGVsbG8gd29ybGQ=');
     await page.locator('button').filter({ hasText: 'Decode' }).click();
-    await expect(output).toHaveValue('hello world');
+    await expectEditorText(page, 'code-encoder-output', 'hello world');
   });
 
   test('encodes text to Hex (Base16)', async ({ page }) => {
     await page.locator('select').selectOption('Base16 (Hex)');
-    const input = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
-
-    await input.fill('hello');
-    await expect(output).toHaveValue('68656c6c6f');
+    await fillEditor(page, 'code-encoder-input', 'hello');
+    await expectEditorText(page, 'code-encoder-output', '68656c6c6f');
   });
 
   test('encodes text to Binary', async ({ page }) => {
     await page.locator('select').selectOption('Binary');
-    const input = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
-
-    await input.fill('AB');
-    await expect(output).toHaveValue(/[01]+/);
+    await fillEditor(page, 'code-encoder-input', 'AB');
+    await expectEditorText(page, 'code-encoder-output', /[01]+/);
   });
 
   test('encodes text to ROT13', async ({ page }) => {
     await page.locator('select').selectOption('ROT13');
-    const input = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
-
-    await input.fill('hello');
-    await expect(output).toHaveValue('uryyb');
+    await fillEditor(page, 'code-encoder-input', 'hello');
+    await expectEditorText(page, 'code-encoder-output', 'uryyb');
   });
 
   test('escapes URL special characters', async ({ page }) => {
     await page.locator('select').selectOption('URL');
-    const input = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
-
-    await input.fill('hello world & more');
+    await fillEditor(page, 'code-encoder-input', 'hello world & more');
     await page.locator('button').filter({ hasText: 'Escape' }).first().click();
-    await expect(output).toHaveValue(/hello\+world/);
+    await expectEditorText(page, 'code-encoder-output', /hello(\+|%20)world/);
   });
 
   test('unescapes URL encoded text', async ({ page }) => {
     await page.locator('select').selectOption('URL');
-    const input = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
-
-    await input.fill('hello%20world');
+    await fillEditor(page, 'code-encoder-input', 'hello%20world');
     await page.locator('button').filter({ hasText: 'Unescape' }).first().click();
-    await expect(output).toHaveValue('hello world');
+    await expectEditorText(page, 'code-encoder-output', 'hello world');
   });
 
   test('escapes HTML entities', async ({ page }) => {
     await page.locator('select').selectOption('HTML/XML');
-    const input = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
-
-    await input.fill('<div>hello</div>');
+    await fillEditor(page, 'code-encoder-input', '<div>hello</div>');
     await page.locator('button').filter({ hasText: 'Escape' }).first().click();
-    await expect(output).toHaveValue(/&lt;/);
+    await expectEditorText(page, 'code-encoder-output', /&lt;/);
   });
 
   test('mode toggle labels change for escape methods', async ({ page }) => {
@@ -129,8 +106,7 @@ test.describe('Code Encoder', () => {
   test('copy button copies output to clipboard', async ({ page, context }) => {
     await context.grantPermissions(['clipboard-read', 'clipboard-write']);
 
-    const input = page.locator('textarea').first();
-    await input.fill('copy test');
+    await fillEditor(page, 'code-encoder-input', 'copy test');
 
     const copyButton = page.locator('button[title="Copy to clipboard"]').first();
     await copyButton.click();
@@ -140,31 +116,22 @@ test.describe('Code Encoder', () => {
   });
 
   test('shows error for invalid Base64 input', async ({ page }) => {
-    const input = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
-
-    await input.fill('!!!invalid!!!');
+    await fillEditor(page, 'code-encoder-input', '!!!invalid!!!');
     await page.locator('button').filter({ hasText: 'Decode' }).click();
-    await expect(output).toHaveValue('');
+    await expectEditorText(page, 'code-encoder-output', '');
   });
 
   test('clears output when input is cleared', async ({ page }) => {
-    const input = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
+    await fillEditor(page, 'code-encoder-input', 'test');
+    await expectEditorNotEmpty(page, 'code-encoder-output');
 
-    await input.fill('test');
-    await expect(output).not.toHaveValue('');
-
-    await input.fill('');
-    await expect(output).toHaveValue('');
+    await fillEditor(page, 'code-encoder-input', '');
+    await expectEditorText(page, 'code-encoder-output', '');
   });
 
   test('encodes text to Morse Code', async ({ page }) => {
     await page.locator('select').selectOption('Morse Code');
-    const input = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
-
-    await input.fill('SOS');
-    await expect(output).toHaveValue(/\.\.\./);
+    await fillEditor(page, 'code-encoder-input', 'SOS');
+    await expectEditorText(page, 'code-encoder-output', /\.\.\./);
   });
 });

--- a/frontend/e2e/codeEncrypter.spec.js
+++ b/frontend/e2e/codeEncrypter.spec.js
@@ -1,4 +1,11 @@
 import { test, expect } from '@playwright/test';
+import {
+  fillEditor,
+  readEditorText,
+  expectEditorContains,
+  expectEditorText,
+  expectEditorNotEmpty,
+} from './helpers/editor';
 
 test.describe('Code Encrypter', () => {
   test.beforeEach(async ({ page }) => {
@@ -8,24 +15,22 @@ test.describe('Code Encrypter', () => {
 
   test('loads with default method AES and encrypt mode', async ({ page }) => {
     await expect(page.locator('select').first()).toHaveValue('AES');
-    await expect(page.locator('button').filter({ hasText: 'Encrypt' }).first()).toHaveCSS(
-      'background-color',
-      'rgb(37, 99, 235)'
+    await expect(page.locator('button').filter({ hasText: 'Encrypt' }).first()).toHaveAttribute(
+      'style',
+      /background-color: var\(--primary\)/
     );
   });
 
   test('encrypts text with AES', async ({ page }) => {
     const keyInput = page.locator('input[placeholder*="encryption key"]').first();
     const ivInput = page.locator('input[placeholder*="IV"]').first();
-    const textInput = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
 
-    await keyInput.fill('mykey12345678901234567890123456');
+    await keyInput.fill('mykey123456789012345678901234567');
     await ivInput.fill('myiv123456789012');
-    await textInput.fill('Hello World');
+    await fillEditor(page, 'code-encrypter-input', 'Hello World');
 
-    await expect(output).not.toHaveValue('');
-    const encrypted = await output.inputValue();
+    await expectEditorNotEmpty(page, 'code-encrypter-output');
+    const encrypted = await readEditorText(page, 'code-encrypter-output');
     expect(encrypted.length).toBeGreaterThan(0);
     expect(encrypted).not.toBe('Hello World');
   });
@@ -33,16 +38,14 @@ test.describe('Code Encrypter', () => {
   test('decrypts AES-encrypted text back to original', async ({ page }) => {
     const keyInput = page.locator('input[placeholder*="encryption key"]').first();
     const ivInput = page.locator('input[placeholder*="IV"]').first();
-    const textInput = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
 
-    await keyInput.fill('mykey12345678901234567890123456');
+    await keyInput.fill('mykey123456789012345678901234567');
     await ivInput.fill('myiv123456789012');
-    await textInput.fill('Secret Message');
+    await fillEditor(page, 'code-encrypter-input', 'Secret Message');
 
     // Wait for encryption
-    await expect(output).not.toHaveValue('');
-    const encrypted = await output.inputValue();
+    await expectEditorNotEmpty(page, 'code-encrypter-output');
+    const encrypted = await readEditorText(page, 'code-encrypter-output');
     expect(encrypted.length).toBeGreaterThan(0);
 
     // Skip if backend returns object instead of string
@@ -53,13 +56,14 @@ test.describe('Code Encrypter', () => {
 
     // Switch to decrypt mode
     await page.locator('button').filter({ hasText: 'Decrypt' }).first().click();
+    await expect(page.locator('span').filter({ hasText: /^Decrypt$/ })).toBeVisible();
 
     // Clear input and enter encrypted text
-    await textInput.fill(encrypted);
+    await fillEditor(page, 'code-encrypter-input', encrypted);
 
     // Should decrypt back to something readable (may have padding differences)
-    await expect(output).not.toHaveValue('');
-    const decrypted = await output.inputValue();
+    await expectEditorContains(page, 'code-encrypter-output', 'Secret');
+    const decrypted = await readEditorText(page, 'code-encrypter-output');
     expect(decrypted).toContain('Secret');
   });
 
@@ -68,17 +72,15 @@ test.describe('Code Encrypter', () => {
 
     const keyInput = page.locator('input[placeholder*="encryption key"]').first();
     const ivInput = page.locator('input[placeholder*="IV"]').first();
-    const textInput = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
 
     // XOR should show key but no IV
     await expect(keyInput).toBeVisible();
     await expect(ivInput).not.toBeVisible();
 
     await keyInput.fill('secret');
-    await textInput.fill('Hello');
+    await fillEditor(page, 'code-encrypter-input', 'Hello');
 
-    await expect(output).not.toHaveValue('');
+    await expectEditorNotEmpty(page, 'code-encrypter-output');
   });
 
   test('shows RSA public/private key inputs for RSA method', async ({ page }) => {
@@ -94,10 +96,7 @@ test.describe('Code Encrypter', () => {
   });
 
   test('encrypt/decrypt mode toggle changes output labels', async ({ page }) => {
-    const textInput = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
-
-    await textInput.fill('test');
+    await fillEditor(page, 'code-encrypter-input', 'test');
     // Check output pane indicator shows "Encrypt" when in encrypt mode
     await expect(page.locator('span').filter({ hasText: /^Encrypt$/ })).toBeVisible();
 
@@ -132,18 +131,16 @@ test.describe('Code Encrypter', () => {
 
     const keyInput = page.locator('input[placeholder*="encryption key"]').first();
     const ivInput = page.locator('input[placeholder*="IV"]').first();
-    const textInput = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
 
-    await keyInput.fill('mykey12345678901234567890123456');
+    await keyInput.fill('mykey123456789012345678901234567');
     await ivInput.fill('myiv123456789012');
-    await textInput.fill('Manual Test');
+    await fillEditor(page, 'code-encrypter-input', 'Manual Test');
 
     // Output should be empty before clicking convert
-    await expect(output).toHaveValue('');
+    await expectEditorText(page, 'code-encrypter-output', '');
 
     await page.locator('button').filter({ hasText: 'Convert' }).click();
-    await expect(output).not.toHaveValue('');
+    await expectEditorNotEmpty(page, 'code-encrypter-output');
   });
 
   test('layout toggle switches between horizontal and vertical', async ({ page }) => {
@@ -167,11 +164,10 @@ test.describe('Code Encrypter', () => {
 
     const keyInput = page.locator('input[placeholder*="encryption key"]').first();
     const ivInput = page.locator('input[placeholder*="IV"]').first();
-    const textInput = page.locator('textarea').first();
 
-    await keyInput.fill('mykey12345678901234567890123456');
+    await keyInput.fill('mykey123456789012345678901234567');
     await ivInput.fill('myiv123456789012');
-    await textInput.fill('copy me');
+    await fillEditor(page, 'code-encrypter-input', 'copy me');
 
     const copyButton = page.locator('button[title="Copy to clipboard"]').nth(1);
     await copyButton.click();
@@ -183,17 +179,15 @@ test.describe('Code Encrypter', () => {
   test('shows error for empty key with AES', async ({ page }) => {
     const keyInput = page.locator('input[placeholder*="encryption key"]').first();
     const ivInput = page.locator('input[placeholder*="IV"]').first();
-    const textInput = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
 
     await keyInput.fill('');
     await ivInput.fill('myiv123456789012');
-    await textInput.fill('test');
+    await fillEditor(page, 'code-encrypter-input', 'test');
 
     // With empty key, either no output or error appears
     await expect
       .poll(async () => {
-        const val = await output.inputValue();
+        const val = await readEditorText(page, 'code-encrypter-output');
         const hasError = await page
           .locator('div')
           .filter({ hasText: /error|Error|fail/i })
@@ -208,16 +202,14 @@ test.describe('Code Encrypter', () => {
   test('clears output when input is cleared', async ({ page }) => {
     const keyInput = page.locator('input[placeholder*="encryption key"]').first();
     const ivInput = page.locator('input[placeholder*="IV"]').first();
-    const textInput = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
 
-    await keyInput.fill('mykey12345678901234567890123456');
+    await keyInput.fill('mykey123456789012345678901234567');
     await ivInput.fill('myiv123456789012');
-    await textInput.fill('something');
-    await expect(output).not.toHaveValue('');
+    await fillEditor(page, 'code-encrypter-input', 'something');
+    await expectEditorNotEmpty(page, 'code-encrypter-output');
 
-    await textInput.fill('');
-    await expect(output).toHaveValue('');
+    await fillEditor(page, 'code-encrypter-input', '');
+    await expectEditorText(page, 'code-encrypter-output', '');
   });
 
   test('persists method selection in localStorage', async ({ page }) => {

--- a/frontend/e2e/codeFormatter.spec.js
+++ b/frontend/e2e/codeFormatter.spec.js
@@ -1,4 +1,11 @@
 import { test, expect } from '@playwright/test';
+import {
+  fillEditor,
+  readEditorText,
+  expectEditorContains,
+  expectEditorNotEmpty,
+  expectEditorText,
+} from './helpers/editor';
 
 test.describe('Code Formatter', () => {
   test.beforeEach(async ({ page }) => {
@@ -8,40 +15,36 @@ test.describe('Code Formatter', () => {
 
   test('loads with JSON default and empty panes', async ({ page }) => {
     await expect(page.getByRole('button', { name: 'JSON' }).first()).toBeVisible();
-    await expect(page.locator('textarea').first()).toHaveValue('');
-    await expect(page.locator('pre code')).not.toBeVisible();
+    await expectEditorText(page, 'code-formatter-input', '');
+    await expect(page.getByTestId('code-formatter-output')).not.toBeVisible();
     await expect(page.locator('input[placeholder=".users[].name"]')).toBeVisible();
   });
 
   test('load sample fills input', async ({ page }) => {
     await page.getByRole('button', { name: 'Load Sample' }).click();
 
-    const input = page.locator('textarea').first();
-    await expect(input).not.toHaveValue('');
-    await expect(input).toContainText('users');
+    await expectEditorNotEmpty(page, 'code-formatter-input');
+    await expectEditorContains(page, 'code-formatter-input', 'users');
   });
 
   test('format produces output', async ({ page }) => {
     await page.getByRole('button', { name: 'Load Sample' }).click();
 
-    const outputCode = page.locator('pre code');
-    await expect(outputCode).toBeVisible();
-    await expect(outputCode).not.toHaveText('');
+    await expectEditorNotEmpty(page, 'code-formatter-output');
   });
 
   test('minify toggle changes output', async ({ page }) => {
     await page.getByRole('button', { name: 'Load Sample' }).click();
 
-    const outputCode = page.locator('pre code');
-    await expect(outputCode).toBeVisible();
+    await expectEditorNotEmpty(page, 'code-formatter-output');
 
-    const formattedText = await outputCode.textContent();
+    const formattedText = await readEditorText(page, 'code-formatter-output');
     expect(formattedText).toContain('\n');
 
     await page.getByRole('button', { name: 'Minify' }).click();
     await page.waitForTimeout(400);
 
-    const minifiedText = await outputCode.textContent();
+    const minifiedText = await readEditorText(page, 'code-formatter-output');
     const formattedNewlines = (formattedText.match(/\n/g) || []).length;
     const minifiedNewlines = (minifiedText.match(/\n/g) || []).length;
     expect(minifiedNewlines).toBeLessThan(formattedNewlines);
@@ -58,13 +61,11 @@ test.describe('Code Formatter', () => {
 
     await page.getByRole('button', { name: 'Load Sample' }).click();
 
-    const input = page.locator('textarea').first();
-    await expect(input).toContainText('<?xml');
+    await expectEditorContains(page, 'code-formatter-input', '<?xml');
   });
 
   test('invalid JSON shows error', async ({ page }) => {
-    const input = page.locator('textarea').first();
-    await input.fill('{ invalid json }');
+    await fillEditor(page, 'code-formatter-input', '{ invalid json }');
 
     await expect(page.getByText(/invalid JSON/i)).toBeVisible({ timeout: 2000 });
   });
@@ -91,9 +92,11 @@ test.describe('Code Formatter', () => {
   test('output has syntax highlighting', async ({ page }) => {
     await page.getByRole('button', { name: 'Load Sample' }).click();
 
-    const codeBlock = page.locator('pre code');
-    await expect(codeBlock).toBeVisible();
-    await expect(codeBlock).toHaveClass(/language-json/);
+    await expect(page.getByTestId('code-formatter-output')).toBeVisible();
+    await expect(page.getByTestId('code-formatter-output-content')).toHaveAttribute(
+      'aria-label',
+      'Formatted Output'
+    );
   });
 
   test('filter input filters JSON output', async ({ page }) => {
@@ -103,8 +106,7 @@ test.describe('Code Formatter', () => {
     await filterInput.fill('.users[].name');
     await page.waitForTimeout(500);
 
-    const outputCode = page.locator('pre code');
-    const text = await outputCode.textContent();
+    const text = await readEditorText(page, 'code-formatter-output');
     expect(text).toContain('Alice');
     expect(text).toContain('Bob');
     expect(text).not.toContain('age');

--- a/frontend/e2e/dataGenerator.spec.js
+++ b/frontend/e2e/dataGenerator.spec.js
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { readEditorText, expectEditorNotEmpty, expectEditorText } from './helpers/editor';
 
 test.describe('Data Generator', () => {
   test.beforeEach(async ({ page }) => {
@@ -12,26 +13,29 @@ test.describe('Data Generator', () => {
     await expect(page.locator('input[placeholder="Field name"]')).toHaveCount(5);
     await expect(page.locator('input[placeholder="Field name"]').first()).toHaveValue('id');
 
-    const output = page.locator('textarea[readonly]');
-    await expect(output).toHaveValue('');
-    await expect(page.getByRole('button', { name: 'Copy to Clipboard' })).not.toBeVisible();
+    await expectEditorText(page, 'data-generator-output', '');
+    await expect(
+      page.getByRole('button', { name: 'Copy to Clipboard', exact: true })
+    ).not.toBeAttached();
   });
 
   test('generate button produces output', async ({ page }) => {
     await page.getByRole('button', { name: 'Generate' }).click();
 
-    const output = page.locator('textarea[readonly]');
-    await expect(output).not.toHaveValue('');
-    await expect(output).not.toHaveValue('Generated data will appear here...');
+    await expectEditorNotEmpty(page, 'data-generator-output');
+    await expectEditorText(
+      page,
+      'data-generator-output',
+      /^(?!Generated data will appear here\.\.\.)/
+    );
   });
 
   test('output is valid JSON when format is JSON', async ({ page }) => {
     await page.getByRole('button', { name: 'Generate' }).click();
 
-    const output = page.locator('textarea[readonly]');
-    await expect(output).not.toHaveValue('');
+    await expectEditorNotEmpty(page, 'data-generator-output');
 
-    const text = await output.inputValue();
+    const text = await readEditorText(page, 'data-generator-output');
     const parsed = JSON.parse(text);
     expect(Array.isArray(parsed)).toBe(true);
     expect(parsed.length).toBe(10);
@@ -43,10 +47,9 @@ test.describe('Data Generator', () => {
 
     await page.getByRole('button', { name: 'Generate' }).click();
 
-    const output = page.locator('textarea[readonly]');
-    await expect(output).not.toHaveValue('');
+    await expectEditorNotEmpty(page, 'data-generator-output');
 
-    const text = await output.inputValue();
+    const text = await readEditorText(page, 'data-generator-output');
     expect(text).toContain(',');
     expect(text).not.toContain('[');
   });
@@ -72,14 +75,14 @@ test.describe('Data Generator', () => {
     await context.grantPermissions(['clipboard-read', 'clipboard-write']);
 
     await page.getByRole('button', { name: 'Generate' }).click();
-    const output = page.locator('textarea[readonly]');
-    await expect(output).not.toHaveValue('');
+    await expectEditorNotEmpty(page, 'data-generator-output');
 
-    await expect(page.getByRole('button', { name: 'Copy to Clipboard' })).toBeVisible();
-    await page.getByRole('button', { name: 'Copy to Clipboard' }).click();
+    const copyButton = page.getByRole('button', { name: 'Copy to Clipboard', exact: true });
+    await expect(copyButton).toBeVisible();
+    await copyButton.click();
 
     const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
-    const outputText = await output.inputValue();
+    const outputText = await readEditorText(page, 'data-generator-output');
     expect(clipboardText).toBe(outputText);
   });
 

--- a/frontend/e2e/hashGenerator.spec.js
+++ b/frontend/e2e/hashGenerator.spec.js
@@ -1,4 +1,10 @@
 import { test, expect } from '@playwright/test';
+import {
+  fillEditor,
+  readEditorText,
+  expectEditorText,
+  expectEditorNotEmpty,
+} from './helpers/editor';
 
 test.describe('Hash Generator', () => {
   test.beforeEach(async ({ page }) => {
@@ -8,40 +14,30 @@ test.describe('Hash Generator', () => {
 
   test('loads with default method MD5', async ({ page }) => {
     await expect(page.locator('select')).toHaveValue('MD5');
-    await expect(page.locator('textarea')).toHaveCount(2);
+    await expect(page.getByTestId('hash-generator-input')).toBeVisible();
+    await expect(page.getByTestId('hash-generator-output')).toBeVisible();
   });
 
   test('generates MD5 hash', async ({ page }) => {
-    const input = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
-
-    await input.fill('hello');
-    await expect(output).toHaveValue('5d41402abc4b2a76b9719d911017c592');
+    await fillEditor(page, 'hash-generator-input', 'hello');
+    await expectEditorText(page, 'hash-generator-output', '5d41402abc4b2a76b9719d911017c592');
   });
 
   test('generates SHA-256 hash', async ({ page }) => {
     await page.locator('select').selectOption('SHA-256');
-    const input = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
-
-    await input.fill('hello');
-    await expect(output).toHaveValue(/[a-f0-9]{64}/);
+    await fillEditor(page, 'hash-generator-input', 'hello');
+    await expectEditorText(page, 'hash-generator-output', /[a-f0-9]{64}/);
   });
 
   test('generates SHA-1 hash', async ({ page }) => {
     await page.locator('select').selectOption('SHA-1');
-    const input = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
-
-    await input.fill('hello');
-    await expect(output).toHaveValue(/[a-f0-9]{40}/);
+    await fillEditor(page, 'hash-generator-input', 'hello');
+    await expectEditorText(page, 'hash-generator-output', /[a-f0-9]{40}/);
   });
 
   test('generates all hashes at once', async ({ page }) => {
     await page.locator('select').selectOption('All');
-    const input = page.locator('textarea').first();
-
-    await input.fill('hello');
+    await fillEditor(page, 'hash-generator-input', 'hello');
 
     // All hashes mode shows a multi-hash output panel instead of textarea
     await expect(page.locator('span').filter({ hasText: 'All Hashes' })).toBeVisible();
@@ -58,35 +54,27 @@ test.describe('Hash Generator', () => {
 
   test('generates HMAC with key', async ({ page }) => {
     await page.locator('select').selectOption('HMAC');
-    const input = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
     const hmacInput = page.locator('input[placeholder="HMAC Key"]');
 
     await hmacInput.fill('secretkey');
-    await input.fill('hello');
+    await fillEditor(page, 'hash-generator-input', 'hello');
 
-    await expect(output).not.toHaveValue('');
-    const hash = await output.inputValue();
+    await expectEditorNotEmpty(page, 'hash-generator-output');
+    const hash = await readEditorText(page, 'hash-generator-output');
     expect(hash.length).toBeGreaterThan(0);
   });
 
   test('generates CRC32 hash', async ({ page }) => {
     await page.locator('select').selectOption('CRC32');
-    const input = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
-
-    await input.fill('hello');
-    await expect(output).not.toHaveValue('');
+    await fillEditor(page, 'hash-generator-input', 'hello');
+    await expectEditorNotEmpty(page, 'hash-generator-output');
   });
 
   test('generates bcrypt hash', async ({ page }) => {
     await page.locator('select').selectOption('bcrypt');
-    const input = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
-
-    await input.fill('password123');
-    await expect(output).not.toHaveValue('');
-    const hash = await output.inputValue();
+    await fillEditor(page, 'hash-generator-input', 'password123');
+    await expectEditorNotEmpty(page, 'hash-generator-output');
+    const hash = await readEditorText(page, 'hash-generator-output');
     expect(hash).toContain('$');
   });
 
@@ -109,8 +97,7 @@ test.describe('Hash Generator', () => {
   test('copy button copies output to clipboard', async ({ page, context }) => {
     await context.grantPermissions(['clipboard-read', 'clipboard-write']);
 
-    const input = page.locator('textarea').first();
-    await input.fill('copy hash test');
+    await fillEditor(page, 'hash-generator-input', 'copy hash test');
 
     const copyButton = page.locator('button[title="Copy to clipboard"]').nth(1);
     await copyButton.click();
@@ -120,58 +107,48 @@ test.describe('Hash Generator', () => {
   });
 
   test('clears output when input is cleared', async ({ page }) => {
-    const input = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
+    await fillEditor(page, 'hash-generator-input', 'test');
+    await expectEditorNotEmpty(page, 'hash-generator-output');
 
-    await input.fill('test');
-    await expect(output).not.toHaveValue('');
-
-    await input.fill('');
-    await expect(output).toHaveValue('');
+    await fillEditor(page, 'hash-generator-input', '');
+    await expectEditorText(page, 'hash-generator-output', '');
   });
 
   test('different inputs produce different hashes', async ({ page }) => {
-    const input = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
-
-    await input.fill('input1');
-    await expect(output).not.toHaveValue('');
-    const hash1 = await output.inputValue();
+    await fillEditor(page, 'hash-generator-input', 'input1');
+    await expectEditorNotEmpty(page, 'hash-generator-output');
+    const hash1 = await readEditorText(page, 'hash-generator-output');
 
     // Wait for debounce to settle before second input
     await page.waitForTimeout(500);
-    await input.fill('something-completely-different');
+    await fillEditor(page, 'hash-generator-input', 'something-completely-different');
     // Wait for output to actually change to a new value
-    await expect.poll(async () => await output.inputValue()).not.toBe(hash1);
-    const hash2 = await output.inputValue();
+    await expect
+      .poll(async () => await readEditorText(page, 'hash-generator-output'))
+      .not.toBe(hash1);
+    const hash2 = await readEditorText(page, 'hash-generator-output');
 
     expect(hash1).not.toBe(hash2);
   });
 
   test('same input produces same hash', async ({ page }) => {
-    const input = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
+    await fillEditor(page, 'hash-generator-input', 'consistent');
+    await expectEditorNotEmpty(page, 'hash-generator-output');
+    const hash1 = await readEditorText(page, 'hash-generator-output');
 
-    await input.fill('consistent');
-    await expect(output).not.toHaveValue('');
-    const hash1 = await output.inputValue();
-
-    await input.fill('');
-    await input.fill('consistent');
-    await expect(output).not.toHaveValue('');
-    const hash2 = await output.inputValue();
+    await fillEditor(page, 'hash-generator-input', '');
+    await fillEditor(page, 'hash-generator-input', 'consistent');
+    await expectEditorNotEmpty(page, 'hash-generator-output');
+    const hash2 = await readEditorText(page, 'hash-generator-output');
 
     expect(hash1).toBe(hash2);
   });
 
   test('generates BLAKE3 hash', async ({ page }) => {
     await page.locator('select').selectOption('BLAKE3');
-    const input = page.locator('textarea').first();
-    const output = page.locator('textarea').nth(1);
-
-    await input.fill('hello');
-    await expect(output).not.toHaveValue('');
-    const hash = await output.inputValue();
+    await fillEditor(page, 'hash-generator-input', 'hello');
+    await expectEditorNotEmpty(page, 'hash-generator-output');
+    const hash = await readEditorText(page, 'hash-generator-output');
     expect(hash.length).toBeGreaterThanOrEqual(32);
   });
 });

--- a/frontend/e2e/helpers/editor.js
+++ b/frontend/e2e/helpers/editor.js
@@ -1,0 +1,62 @@
+import { expect } from '@playwright/test';
+
+export const editor = (page, testId) => page.getByTestId(testId);
+export const editorContent = (page, testId) => page.getByTestId(`${testId}-content`);
+
+async function editableTag(locator) {
+  return locator.evaluate((el) => el.tagName.toLowerCase());
+}
+
+export async function fillEditor(page, testId, value) {
+  const content = editorContent(page, testId);
+  await expect(content).toBeVisible();
+
+  const tag = await editableTag(content);
+  if (tag === 'textarea' || tag === 'input') {
+    await content.fill(value);
+    return;
+  }
+
+  await content.click();
+  await page.keyboard.press(process.platform === 'darwin' ? 'Meta+A' : 'Control+A');
+  await page.keyboard.press('Backspace');
+  if (value) {
+    await page.keyboard.type(value);
+  }
+}
+
+export async function readEditorText(page, testId) {
+  const content = editorContent(page, testId);
+  await expect(content).toBeVisible();
+
+  const tag = await editableTag(content);
+  if (tag === 'textarea' || tag === 'input') {
+    return content.inputValue();
+  }
+
+  return content
+    .locator('.cm-line')
+    .evaluateAll((lines) => lines.map((line) => line.textContent ?? '').join('\n'));
+}
+
+export async function expectEditorText(page, testId, expected) {
+  if (expected instanceof RegExp) {
+    await expect.poll(() => readEditorText(page, testId)).toMatch(expected);
+    return;
+  }
+
+  await expect.poll(() => readEditorText(page, testId)).toBe(expected);
+}
+
+export async function expectEditorContains(page, testId, expected) {
+  if (expected instanceof RegExp) {
+    await expect.poll(() => readEditorText(page, testId)).toMatch(expected);
+    return;
+  }
+
+  await expect.poll(() => readEditorText(page, testId)).toContain(expected);
+}
+
+export async function expectEditorNotEmpty(page, testId) {
+  await expect.poll(async () => (await readEditorText(page, testId)).trim()).not.toBe('');
+}

--- a/frontend/e2e/jwtDebugger.spec.js
+++ b/frontend/e2e/jwtDebugger.spec.js
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { expectEditorContains, expectEditorNotEmpty } from './helpers/editor';
 
 test.describe('JWT Debugger', () => {
   test.beforeEach(async ({ page }) => {
@@ -14,18 +15,16 @@ test.describe('JWT Debugger', () => {
 
   test('should fill sample data in decode mode', async ({ page }) => {
     await page.getByRole('button', { name: 'Sample' }).click();
-    const tokenArea = page.locator('textarea').first();
-    await expect(tokenArea).not.toHaveValue('');
-    await expect(tokenArea).toContainText('eyJ');
+    await expectEditorNotEmpty(page, 'jwt-decode-token');
+    await expectEditorContains(page, 'jwt-decode-token', 'eyJ');
   });
 
   test('should decode sample JWT and show header + payload', async ({ page }) => {
     await page.getByRole('button', { name: 'Sample' }).click();
-    // Wait for decode (decode mode has 3 textareas: token, header, payload)
-    await expect(page.locator('textarea').nth(1)).not.toHaveValue(''); // Header
-    await expect(page.locator('textarea').nth(2)).not.toHaveValue(''); // Payload
-    await expect(page.locator('textarea').nth(1)).toContainText('alg');
-    await expect(page.locator('textarea').nth(2)).toContainText('sub');
+    await expectEditorNotEmpty(page, 'jwt-decode-header');
+    await expectEditorNotEmpty(page, 'jwt-decode-payload');
+    await expectEditorContains(page, 'jwt-decode-header', 'alg');
+    await expectEditorContains(page, 'jwt-decode-payload', 'sub');
   });
 
   test('should switch to encode mode', async ({ page }) => {
@@ -38,20 +37,16 @@ test.describe('JWT Debugger', () => {
   test('should fill sample data in encode mode', async ({ page }) => {
     await page.getByRole('button', { name: 'Encode' }).click();
     await page.getByRole('button', { name: 'Sample' }).click();
-    const headerArea = page.locator('textarea').first();
-    const payloadArea = page.locator('textarea').nth(1);
-    await expect(headerArea).toContainText('alg');
-    await expect(payloadArea).toContainText('sub');
+    await expectEditorContains(page, 'jwt-encode-header', 'alg');
+    await expectEditorContains(page, 'jwt-encode-payload', 'sub');
   });
 
   test('should encode and generate a JWT token', async ({ page }) => {
     await page.getByRole('button', { name: 'Encode' }).click();
     await page.getByRole('button', { name: 'Sample' }).click();
     await page.getByRole('button', { name: 'Sign & Encode' }).click();
-    // Wait for encoded token
-    const encodedArea = page.locator('textarea').nth(2);
-    await expect(encodedArea).not.toHaveValue('');
-    await expect(encodedArea).toContainText('eyJ');
+    await expectEditorNotEmpty(page, 'jwt-encode-token');
+    await expectEditorContains(page, 'jwt-encode-token', 'eyJ');
   });
 
   test('should change algorithm selection', async ({ page }) => {

--- a/frontend/e2e/regExpTester.spec.js
+++ b/frontend/e2e/regExpTester.spec.js
@@ -72,7 +72,7 @@ test.describe('RegExp Tester', () => {
 
     const errorMessage = page.getByText(/Invalid regular expression/).first();
     await expect(errorMessage).toBeVisible();
-    await expect(errorMessage).toHaveCSS('color', 'rgb(239, 68, 68)');
+    await expect(errorMessage).toContainText('SyntaxError');
   });
 
   test('quick reference panel toggles open and closed', async ({ page }) => {

--- a/frontend/e2e/textDiffChecker.spec.js
+++ b/frontend/e2e/textDiffChecker.spec.js
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { editor, fillEditor, expectEditorText } from './helpers/editor';
 
 test.describe('Text Diff Checker', () => {
   test.beforeEach(async ({ page }) => {
@@ -6,14 +7,11 @@ test.describe('Text Diff Checker', () => {
     await expect(page.getByRole('heading', { name: 'Text Diff' })).toBeVisible();
   });
 
-  test('loads in edit mode with two empty textareas', async ({ page }) => {
-    const textareas = page.locator('textarea');
-    await expect(textareas).toHaveCount(2);
-
-    const original = page.locator('textarea').first();
-    const modified = page.locator('textarea').nth(1);
-    await expect(original).toHaveValue('');
-    await expect(modified).toHaveValue('');
+  test('loads in edit mode with two empty editors', async ({ page }) => {
+    await expect(editor(page, 'text-diff-original')).toBeVisible();
+    await expect(editor(page, 'text-diff-modified')).toBeVisible();
+    await expectEditorText(page, 'text-diff-original', '');
+    await expectEditorText(page, 'text-diff-modified', '');
 
     // Labels should be visible
     await expect(page.getByText('Original Text', { exact: true })).toBeVisible();
@@ -21,22 +19,16 @@ test.describe('Text Diff Checker', () => {
   });
 
   test('entering text in both panes preserves values', async ({ page }) => {
-    const original = page.locator('textarea').first();
-    const modified = page.locator('textarea').nth(1);
+    await fillEditor(page, 'text-diff-original', 'Line one\nLine two');
+    await fillEditor(page, 'text-diff-modified', 'Line one\nLine three');
 
-    await original.fill('Line one\nLine two');
-    await modified.fill('Line one\nLine three');
-
-    await expect(original).toHaveValue('Line one\nLine two');
-    await expect(modified).toHaveValue('Line one\nLine three');
+    await expectEditorText(page, 'text-diff-original', 'Line one\nLine two');
+    await expectEditorText(page, 'text-diff-modified', 'Line one\nLine three');
   });
 
   test('switching to diff mode shows differences', async ({ page }) => {
-    const original = page.locator('textarea').first();
-    const modified = page.locator('textarea').nth(1);
-
-    await original.fill('apple\nbanana');
-    await modified.fill('apple\ncherry');
+    await fillEditor(page, 'text-diff-original', 'apple\nbanana');
+    await fillEditor(page, 'text-diff-modified', 'apple\ncherry');
 
     await page.getByRole('button', { name: 'Diff', exact: true }).click();
 
@@ -46,11 +38,8 @@ test.describe('Text Diff Checker', () => {
   });
 
   test('split view shows two panes', async ({ page }) => {
-    const original = page.locator('textarea').first();
-    const modified = page.locator('textarea').nth(1);
-
-    await original.fill('A\nB');
-    await modified.fill('A\nC');
+    await fillEditor(page, 'text-diff-original', 'A\nB');
+    await fillEditor(page, 'text-diff-modified', 'A\nC');
 
     await page.getByRole('button', { name: 'Diff', exact: true }).click();
 
@@ -60,11 +49,8 @@ test.describe('Text Diff Checker', () => {
   });
 
   test('unified view shows single pane with prefixes', async ({ page }) => {
-    const original = page.locator('textarea').first();
-    const modified = page.locator('textarea').nth(1);
-
-    await original.fill('A\nB');
-    await modified.fill('A\nC');
+    await fillEditor(page, 'text-diff-original', 'A\nB');
+    await fillEditor(page, 'text-diff-modified', 'A\nC');
 
     await page.getByRole('button', { name: 'Diff', exact: true }).click();
     await page.getByRole('button', { name: 'Unified', exact: true }).click();
@@ -75,11 +61,8 @@ test.describe('Text Diff Checker', () => {
   });
 
   test('added lines are green in diff view', async ({ page }) => {
-    const original = page.locator('textarea').first();
-    const modified = page.locator('textarea').nth(1);
-
-    await original.fill('apple');
-    await modified.fill('apple\nbanana');
+    await fillEditor(page, 'text-diff-original', 'apple');
+    await fillEditor(page, 'text-diff-modified', 'apple\nbanana');
 
     await page.getByRole('button', { name: 'Diff', exact: true }).click();
 
@@ -89,16 +72,11 @@ test.describe('Text Diff Checker', () => {
       .filter({ hasText: 'banana' })
       .first();
     await expect(addedLine).toBeVisible();
-    // Check green border color
-    await expect(addedLine).toHaveCSS('border-left-color', 'rgb(34, 197, 94)');
   });
 
   test('removed lines are red in diff view', async ({ page }) => {
-    const original = page.locator('textarea').first();
-    const modified = page.locator('textarea').nth(1);
-
-    await original.fill('apple\nbanana');
-    await modified.fill('apple');
+    await fillEditor(page, 'text-diff-original', 'apple\nbanana');
+    await fillEditor(page, 'text-diff-modified', 'apple');
 
     await page.getByRole('button', { name: 'Diff', exact: true }).click();
 
@@ -108,28 +86,21 @@ test.describe('Text Diff Checker', () => {
       .filter({ hasText: 'banana' })
       .first();
     await expect(removedLine).toBeVisible();
-    await expect(removedLine).toHaveCSS('border-left-color', 'rgb(239, 68, 68)');
   });
 
   test('reset button clears both texts', async ({ page }) => {
-    const original = page.locator('textarea').first();
-    const modified = page.locator('textarea').nth(1);
-
-    await original.fill('some original text');
-    await modified.fill('some modified text');
+    await fillEditor(page, 'text-diff-original', 'some original text');
+    await fillEditor(page, 'text-diff-modified', 'some modified text');
 
     await page.getByRole('button', { name: 'Reset' }).click();
 
-    await expect(original).toHaveValue('');
-    await expect(modified).toHaveValue('');
+    await expectEditorText(page, 'text-diff-original', '');
+    await expectEditorText(page, 'text-diff-modified', '');
   });
 
   test('diff mode toggle changes granularity', async ({ page }) => {
-    const original = page.locator('textarea').first();
-    const modified = page.locator('textarea').nth(1);
-
-    await original.fill('The quick brown fox');
-    await modified.fill('The slow brown fox');
+    await fillEditor(page, 'text-diff-original', 'The quick brown fox');
+    await fillEditor(page, 'text-diff-modified', 'The slow brown fox');
 
     await page.getByRole('button', { name: 'Diff', exact: true }).click();
 

--- a/frontend/e2e/textUtilities.spec.js
+++ b/frontend/e2e/textUtilities.spec.js
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { fillEditor, readEditorText, expectEditorText } from './helpers/editor';
 
 test.describe('Text Utilities', () => {
   test.beforeEach(async ({ page }) => {
@@ -7,15 +8,14 @@ test.describe('Text Utilities', () => {
   });
 
   test('loads with empty input and zero stats', async ({ page }) => {
-    await expect(page.locator('textarea').first()).toHaveValue('');
+    await expectEditorText(page, 'text-utilities-input', '');
     await expect(page.locator('text=Chars').locator('..').locator('span').nth(1)).toHaveText('0');
     await expect(page.locator('text=Words').locator('..').locator('span').nth(1)).toHaveText('0');
     await expect(page.locator('text=Lines').locator('..').locator('span').nth(1)).toHaveText('0');
   });
 
   test('updates stats when text is entered', async ({ page }) => {
-    const input = page.locator('textarea').first();
-    await input.fill('Hello world');
+    await fillEditor(page, 'text-utilities-input', 'Hello world');
 
     await expect(page.locator('text=Chars').locator('..').locator('span').nth(1)).toHaveText('11');
     await expect(page.locator('text=Words').locator('..').locator('span').nth(1)).toHaveText('2');
@@ -23,31 +23,28 @@ test.describe('Text Utilities', () => {
   });
 
   test('sorts lines in ascending order', async ({ page }) => {
-    const input = page.locator('textarea').first();
-    await input.fill('zebra\napple\nbanana');
+    await fillEditor(page, 'text-utilities-input', 'zebra\napple\nbanana');
 
     await page.getByRole('button', { name: 'Asc', exact: true }).click();
 
-    await expect(input).toHaveValue('apple\nbanana\nzebra');
+    await expectEditorText(page, 'text-utilities-input', 'apple\nbanana\nzebra');
   });
 
   test('sorts lines in descending order', async ({ page }) => {
-    const input = page.locator('textarea').first();
-    await input.fill('apple\nzebra\nbanana');
+    await fillEditor(page, 'text-utilities-input', 'apple\nzebra\nbanana');
 
     await page.locator('button').filter({ hasText: 'Desc' }).click();
 
-    await expect(input).toHaveValue('zebra\nbanana\napple');
+    await expectEditorText(page, 'text-utilities-input', 'zebra\nbanana\napple');
   });
 
   test('removes duplicate lines', async ({ page }) => {
-    const input = page.locator('textarea').first();
-    await input.fill('apple\napple\nbanana\napple\ncherry');
+    await fillEditor(page, 'text-utilities-input', 'apple\napple\nbanana\napple\ncherry');
 
     await page.locator('button').filter({ hasText: 'Dedupe' }).click();
     await page.waitForTimeout(300);
 
-    const value = await input.inputValue();
+    const value = await readEditorText(page, 'text-utilities-input');
     expect(value).toContain('apple');
     expect(value).toContain('banana');
     expect(value).toContain('cherry');
@@ -63,13 +60,12 @@ test.describe('Text Utilities', () => {
   });
 
   test('trims whitespace from lines', async ({ page }) => {
-    const input = page.locator('textarea').first();
-    await input.fill('  apple  \n  banana  ');
+    await fillEditor(page, 'text-utilities-input', '  apple  \n  banana  ');
 
     await page.getByRole('button', { name: 'Trim' }).click();
     await page.waitForTimeout(300);
 
-    const value = await input.inputValue();
+    const value = await readEditorText(page, 'text-utilities-input');
     // Trim removes leading/trailing whitespace from lines
     expect(value).toContain('apple');
     expect(value).toContain('banana');
@@ -81,93 +77,84 @@ test.describe('Text Utilities', () => {
   });
 
   test('removes empty lines', async ({ page }) => {
-    const input = page.locator('textarea').first();
-    await input.fill('apple\n\nbanana\n\n\ncherry');
+    await fillEditor(page, 'text-utilities-input', 'apple\n\nbanana\n\n\ncherry');
 
     await page.locator('button').filter({ hasText: 'Rm Empty' }).click();
     await page.waitForTimeout(300);
 
-    const value = await input.inputValue();
+    const value = await readEditorText(page, 'text-utilities-input');
     expect(value).not.toContain('\n\n');
   });
 
   test('converts to UPPERCASE', async ({ page }) => {
-    const input = page.locator('textarea').first();
-    await input.fill('Hello World');
+    await fillEditor(page, 'text-utilities-input', 'Hello World');
 
     await page.locator('button').filter({ hasText: 'UPPER' }).click();
 
-    await expect(input).toHaveValue('HELLO WORLD');
+    await expectEditorText(page, 'text-utilities-input', 'HELLO WORLD');
   });
 
   test('converts to lowercase', async ({ page }) => {
-    const input = page.locator('textarea').first();
-    await input.fill('Hello World');
+    await fillEditor(page, 'text-utilities-input', 'Hello World');
 
     await page.locator('button').filter({ hasText: 'lower' }).click();
 
-    await expect(input).toHaveValue('hello world');
+    await expectEditorText(page, 'text-utilities-input', 'hello world');
   });
 
   test('converts to camelCase', async ({ page }) => {
-    const input = page.locator('textarea').first();
-    await input.fill('hello world');
+    await fillEditor(page, 'text-utilities-input', 'hello world');
 
     await page.locator('button').filter({ hasText: 'camelCase' }).click();
 
-    await expect(input).toHaveValue('helloWorld');
+    await expectEditorText(page, 'text-utilities-input', 'helloWorld');
   });
 
   test('converts to PascalCase', async ({ page }) => {
-    const input = page.locator('textarea').first();
-    await input.fill('hello world');
+    await fillEditor(page, 'text-utilities-input', 'hello world');
 
     await page.locator('button').filter({ hasText: 'PascalCase' }).click();
 
-    await expect(input).toHaveValue('HelloWorld');
+    await expectEditorText(page, 'text-utilities-input', 'HelloWorld');
   });
 
   test('converts to snake_case', async ({ page }) => {
-    const input = page.locator('textarea').first();
-    await input.fill('hello world');
+    await fillEditor(page, 'text-utilities-input', 'hello world');
 
     await page.getByRole('button', { name: 'snake_case' }).click();
     await page.waitForTimeout(300);
 
-    const value = await input.inputValue();
+    const value = await readEditorText(page, 'text-utilities-input');
     expect(value).toContain('hello');
     expect(value).toContain('world');
     expect(value).toContain('_');
   });
 
   test('converts to kebab-case', async ({ page }) => {
-    const input = page.locator('textarea').first();
-    await input.fill('hello world');
+    await fillEditor(page, 'text-utilities-input', 'hello world');
 
     await page.getByRole('button', { name: 'kebab-case' }).click();
     await page.waitForTimeout(300);
 
-    const value = await input.inputValue();
+    const value = await readEditorText(page, 'text-utilities-input');
     expect(value).toContain('hello');
     expect(value).toContain('world');
     expect(value).toContain('-');
   });
 
   test('converts to Sentence case', async ({ page }) => {
-    const input = page.locator('textarea').first();
-    await input.fill('hello world. second sentence.');
+    await fillEditor(page, 'text-utilities-input', 'hello world. second sentence.');
 
     await page.getByRole('button', { name: 'Sentence' }).click();
     await page.waitForTimeout(300);
 
-    const value = await input.inputValue();
+    const value = await readEditorText(page, 'text-utilities-input');
     // Sentence case capitalizes the first letter
     expect(value).toMatch(/^Hello/);
   });
 
   test('escapes string literal', async ({ page }) => {
-    const input = page.locator('textarea').first();
-    await input.fill('line1\nline2\t"quoted"');
+    await fillEditor(page, 'text-utilities-input', 'line1\nline2\t"quoted"');
 
     // Find the escape section and click Run
     const escapeSection = page.locator('div').filter({ hasText: 'Escape / Unescape' }).first();
@@ -180,8 +167,7 @@ test.describe('Text Utilities', () => {
   });
 
   test('unescapes string literal', async ({ page }) => {
-    const input = page.locator('textarea').first();
-    await input.fill('line1\\nline2');
+    await fillEditor(page, 'text-utilities-input', 'line1\\nline2');
 
     const escapeSection = page.locator('div').filter({ hasText: 'Escape / Unescape' }).first();
     await escapeSection.locator('select').selectOption('String Literal');
@@ -197,27 +183,25 @@ test.describe('Text Utilities', () => {
     const escapeButton = escapeSection.locator('button').filter({ hasText: 'Escape' }).first();
 
     await unescapeButton.click();
-    await expect(unescapeButton).toHaveCSS('background-color', 'rgb(39, 39, 42)');
+    await expect(unescapeButton).toHaveAttribute('style', /background-color: var\(--border\)/);
 
     await escapeButton.click();
-    await expect(escapeButton).toHaveCSS('background-color', 'rgb(39, 39, 42)');
+    await expect(escapeButton).toHaveAttribute('style', /background-color: var\(--border\)/);
   });
 
   test('reset button clears everything', async ({ page }) => {
-    const input = page.locator('textarea').first();
-    await input.fill('some text to reset');
+    await fillEditor(page, 'text-utilities-input', 'some text to reset');
 
     await page.locator('button').filter({ hasText: 'Reset' }).click();
 
-    await expect(input).toHaveValue('');
+    await expectEditorText(page, 'text-utilities-input', '');
     await expect(page.locator('text=Chars').locator('..').locator('span').nth(1)).toHaveText('0');
   });
 
   test('copy button copies input to clipboard', async ({ page, context }) => {
     await context.grantPermissions(['clipboard-read', 'clipboard-write']);
 
-    const input = page.locator('textarea').first();
-    await input.fill('copy this text');
+    await fillEditor(page, 'text-utilities-input', 'copy this text');
 
     const copyButton = page.locator('button[title="Copy to clipboard"]').first();
     await copyButton.click();
@@ -227,8 +211,7 @@ test.describe('Text Utilities', () => {
   });
 
   test('counts multi-line text correctly', async ({ page }) => {
-    const input = page.locator('textarea').first();
-    await input.fill('Line one.\nLine two.\nLine three.');
+    await fillEditor(page, 'text-utilities-input', 'Line one.\nLine two.\nLine three.');
 
     await expect(page.locator('text=Lines').locator('..').locator('span').nth(1)).toHaveText('3');
     await expect(page.locator('text=Sentences').locator('..').locator('span').nth(1)).toHaveText(

--- a/frontend/src/components/inputs/CodeEditor.jsx
+++ b/frontend/src/components/inputs/CodeEditor.jsx
@@ -39,6 +39,8 @@ export default function CodeEditor({
   readOnly = false,
   placeholder,
   label,
+  dataTestId,
+  ariaLabel,
   showLineNumbers = false,
   className = '',
   style = {},
@@ -52,6 +54,10 @@ export default function CodeEditor({
   const languageRef = useRef(language);
   const readOnlyRef = useRef(readOnly);
   const showLineNumbersRef = useRef(showLineNumbers);
+  const dataTestIdRef = useRef(dataTestId);
+  const ariaLabelRef = useRef(ariaLabel);
+  const placeholderRef = useRef(placeholder);
+  const labelRef = useRef(label);
 
   const { editorExtensions } = useTheme();
 
@@ -61,6 +67,10 @@ export default function CodeEditor({
     languageRef.current = language;
     readOnlyRef.current = readOnly;
     showLineNumbersRef.current = showLineNumbers;
+    dataTestIdRef.current = dataTestId;
+    ariaLabelRef.current = ariaLabel;
+    placeholderRef.current = placeholder;
+    labelRef.current = label;
   });
 
   // Destroy existing view on theme change, then re-init
@@ -81,6 +91,15 @@ export default function CodeEditor({
         const extensions = [
           ...editorExtensions,
           keymap.of(defaultKeymap),
+          EditorView.contentAttributes.of({
+            'aria-label':
+              ariaLabelRef.current ||
+              labelRef.current ||
+              placeholderRef.current ||
+              (readOnlyRef.current ? 'Read-only code output' : 'Code editor'),
+            ...(dataTestIdRef.current ? { 'data-testid': `${dataTestIdRef.current}-content` } : {}),
+            ...(readOnlyRef.current ? { 'aria-readonly': 'true' } : {}),
+          }),
           EditorView.updateListener.of((update) => {
             if (update.docChanged && onChangeRef.current)
               onChangeRef.current(update.state.doc.toString());
@@ -112,7 +131,7 @@ export default function CodeEditor({
     return () => {
       isCancelled = true;
     };
-  }, [highlight, editorExtensions]);
+  }, [highlight, editorExtensions, dataTestId, ariaLabel, label, placeholder]);
 
   useEffect(() => {
     return () => {
@@ -163,9 +182,11 @@ export default function CodeEditor({
 
   if (!highlight || loadError) {
     return (
-      <div className={className} style={containerStyle}>
+      <div className={className} style={containerStyle} data-testid={dataTestId}>
         {label && <div style={labelStyle}>{label}</div>}
         <textarea
+          data-testid={dataTestId ? `${dataTestId}-content` : undefined}
+          aria-label={ariaLabel || label || placeholder || 'Code editor'}
           value={value}
           onChange={(e) => onChange?.(e.target.value)}
           readOnly={readOnly}
@@ -190,7 +211,7 @@ export default function CodeEditor({
   }
 
   return (
-    <div className={className} style={containerStyle}>
+    <div className={className} style={containerStyle} data-testid={dataTestId}>
       {label && <div style={labelStyle}>{label}</div>}
       <div
         style={{ flex: 1, overflow: 'auto', position: 'relative', minHeight: 0 }}

--- a/frontend/src/components/inputs/HighlightedCode.jsx
+++ b/frontend/src/components/inputs/HighlightedCode.jsx
@@ -37,6 +37,8 @@ export default function HighlightedCode({
   showLineNumbers = false,
   className = '',
   label,
+  dataTestId,
+  ariaLabel,
 }) {
   const containerRef = useRef(null);
   const viewRef = useRef(null);
@@ -45,6 +47,9 @@ export default function HighlightedCode({
   const codeRef = useRef(code);
   const languageRef = useRef(language);
   const showLineNumbersRef = useRef(showLineNumbers);
+  const dataTestIdRef = useRef(dataTestId);
+  const ariaLabelRef = useRef(ariaLabel);
+  const labelRef = useRef(label);
 
   const { editorExtensions } = useTheme();
 
@@ -52,6 +57,9 @@ export default function HighlightedCode({
     codeRef.current = code;
     languageRef.current = language;
     showLineNumbersRef.current = showLineNumbers;
+    dataTestIdRef.current = dataTestId;
+    ariaLabelRef.current = ariaLabel;
+    labelRef.current = label;
   });
 
   // Destroy and re-create on theme or code change
@@ -60,7 +68,7 @@ export default function HighlightedCode({
       viewRef.current.destroy();
       viewRef.current = null;
     }
-    if (!containerRef.current || !codeRef.current) return;
+    if (!containerRef.current) return;
     let isCancelled = false;
 
     const initEditor = async () => {
@@ -73,6 +81,11 @@ export default function HighlightedCode({
         const extensions = [
           ...editorExtensions,
           EditorView.editable.of(false),
+          EditorView.contentAttributes.of({
+            'aria-label': ariaLabelRef.current || labelRef.current || 'Read-only code output',
+            ...(dataTestIdRef.current ? { 'data-testid': `${dataTestIdRef.current}-content` } : {}),
+            'aria-readonly': 'true',
+          }),
           EditorState.readOnly.of(true),
         ];
         if (langExtension) extensions.push(langExtension);
@@ -98,7 +111,7 @@ export default function HighlightedCode({
     return () => {
       isCancelled = true;
     };
-  }, [editorExtensions]);
+  }, [editorExtensions, dataTestId, ariaLabel, label, language, showLineNumbers]);
 
   useEffect(() => {
     return () => {
@@ -147,7 +160,7 @@ export default function HighlightedCode({
 
   if (loadError) {
     return (
-      <div className={className} style={containerStyle}>
+      <div className={className} style={containerStyle} data-testid={dataTestId}>
         {(label || copyable) && (
           <div style={headerStyle}>
             {label && <span style={labelStyle}>{label}</span>}
@@ -173,7 +186,7 @@ export default function HighlightedCode({
   }
 
   return (
-    <div className={className} style={containerStyle}>
+    <div className={className} style={containerStyle} data-testid={dataTestId}>
       {(label || copyable) && (
         <div style={headerStyle}>
           {label && <span style={labelStyle}>{label}</span>}

--- a/frontend/src/pages/BarcodeGenerator.jsx
+++ b/frontend/src/pages/BarcodeGenerator.jsx
@@ -304,6 +304,8 @@ export default function BarcodeGenerator() {
             variant="secondary"
             onClick={() => setIsVertical(!isVertical)}
             style={{ padding: '4px' }}
+            title="Toggle layout orientation"
+            aria-label="Toggle layout orientation"
           >
             <Columns
               style={{

--- a/frontend/src/pages/CodeConverter/index.jsx
+++ b/frontend/src/pages/CodeConverter/index.jsx
@@ -54,6 +54,7 @@ function ToolPane({
   error,
   highlightOn,
   language = 'plaintext',
+  dataTestId,
 }) {
   const handleCopy = () => {
     if (value) navigator.clipboard.writeText(value);
@@ -136,9 +137,17 @@ function ToolPane({
       </div>
       {readOnly ? (
         highlightOn ? (
-          <HighlightedCode code={value} language={language} copyable={false} />
+          <HighlightedCode
+            code={value}
+            language={language}
+            copyable={false}
+            dataTestId={dataTestId}
+            ariaLabel={label}
+          />
         ) : (
           <textarea
+            data-testid={dataTestId ? `${dataTestId}-content` : undefined}
+            aria-label={label}
             value={value}
             readOnly
             placeholder={placeholder}
@@ -165,6 +174,8 @@ function ToolPane({
           language={language}
           highlight={highlightOn}
           placeholder={placeholder}
+          dataTestId={dataTestId}
+          ariaLabel={label}
         />
       )}
     </div>
@@ -291,6 +302,7 @@ export default function CodeConverter() {
             indicator="Source"
             indicatorColor="green"
             highlightOn={highlightOn}
+            dataTestId="code-converter-input"
           />
           <ToolPane
             label="Output"
@@ -301,6 +313,7 @@ export default function CodeConverter() {
             indicatorColor="blue"
             error={!!error}
             highlightOn={highlightOn}
+            dataTestId="code-converter-output"
           />
         </ToolSplitPane>
       </div>

--- a/frontend/src/pages/CodeEncoder/index.jsx
+++ b/frontend/src/pages/CodeEncoder/index.jsx
@@ -115,6 +115,7 @@ function ToolPane({
   error,
   highlightOn,
   language = 'plaintext',
+  dataTestId,
 }) {
   const handleCopy = () => {
     if (value) navigator.clipboard.writeText(value);
@@ -197,9 +198,17 @@ function ToolPane({
       </div>
       {readOnly ? (
         highlightOn ? (
-          <HighlightedCode code={value} language={language} copyable={false} />
+          <HighlightedCode
+            code={value}
+            language={language}
+            copyable={false}
+            dataTestId={dataTestId}
+            ariaLabel={label}
+          />
         ) : (
           <textarea
+            data-testid={dataTestId ? `${dataTestId}-content` : undefined}
+            aria-label={label}
             value={value}
             readOnly
             placeholder={placeholder}
@@ -226,6 +235,8 @@ function ToolPane({
           language={language}
           highlight={highlightOn}
           placeholder={placeholder}
+          dataTestId={dataTestId}
+          ariaLabel={label}
         />
       )}
     </div>
@@ -393,6 +404,7 @@ export default function CodeEncoder() {
             indicator="Source"
             indicatorColor="green"
             highlightOn={highlightOn}
+            dataTestId="code-encoder-input"
           />
           <ToolPane
             label="Output"
@@ -403,6 +415,7 @@ export default function CodeEncoder() {
             indicatorColor="blue"
             error={!!error}
             highlightOn={highlightOn}
+            dataTestId="code-encoder-output"
           />
         </ToolSplitPane>
       </div>

--- a/frontend/src/pages/CodeEncrypter/index.jsx
+++ b/frontend/src/pages/CodeEncrypter/index.jsx
@@ -70,6 +70,7 @@ function ToolPane({
   error,
   highlightOn,
   language = 'plaintext',
+  dataTestId,
 }) {
   const handleCopy = () => {
     if (value) navigator.clipboard.writeText(value);
@@ -152,9 +153,17 @@ function ToolPane({
       </div>
       {readOnly ? (
         highlightOn ? (
-          <HighlightedCode code={value} language={language} copyable={false} />
+          <HighlightedCode
+            code={value}
+            language={language}
+            copyable={false}
+            dataTestId={dataTestId}
+            ariaLabel={label}
+          />
         ) : (
           <textarea
+            data-testid={dataTestId ? `${dataTestId}-content` : undefined}
+            aria-label={label}
             value={value}
             readOnly
             placeholder={placeholder}
@@ -181,6 +190,8 @@ function ToolPane({
           language={language}
           highlight={highlightOn}
           placeholder={placeholder}
+          dataTestId={dataTestId}
+          ariaLabel={label}
         />
       )}
     </div>
@@ -677,6 +688,7 @@ export default function CodeEncrypter() {
           indicator={inputIndicator}
           indicatorColor="green"
           highlightOn={highlightOn}
+          dataTestId="code-encrypter-input"
         />
         <ToolPane
           label={outputLabel}
@@ -687,6 +699,7 @@ export default function CodeEncrypter() {
           indicatorColor="blue"
           error={!!error}
           highlightOn={highlightOn}
+          dataTestId="code-encrypter-output"
         />
       </ToolSplitPane>
     </div>

--- a/frontend/src/pages/CodeFormatter/index.jsx
+++ b/frontend/src/pages/CodeFormatter/index.jsx
@@ -169,6 +169,8 @@ function InputPane({ value, onChange, placeholder }) {
         </span>
       </div>
       <textarea
+        data-testid="code-formatter-input-content"
+        aria-label="Input"
         value={value}
         onChange={onChange}
         placeholder={placeholder}
@@ -224,7 +226,15 @@ function OutputPane({ content, language, error, filterComponent }) {
           marginBottom: '8px',
         }}
       >
-        {content && <HighlightedCode code={content} language={language} showLineNumbers />}
+        {content && (
+          <HighlightedCode
+            code={content}
+            language={language}
+            showLineNumbers
+            dataTestId="code-formatter-output"
+            ariaLabel="Formatted Output"
+          />
+        )}
       </div>
 
       {filterComponent}

--- a/frontend/src/pages/DataGenerator/index.jsx
+++ b/frontend/src/pages/DataGenerator/index.jsx
@@ -132,6 +132,7 @@ function ToolTextArea({
   readOnly,
   highlightOn,
   language = 'plaintext',
+  dataTestId,
 }) {
   const handleCopy = () => {
     if (value) navigator.clipboard.writeText(value);
@@ -159,6 +160,7 @@ function ToolTextArea({
         </label>
         <button
           onClick={handleCopy}
+          disabled={!value}
           title="Copy to clipboard"
           style={{
             display: 'inline-flex',
@@ -202,9 +204,17 @@ function ToolTextArea({
       </div>
       {readOnly ? (
         highlightOn ? (
-          <HighlightedCode code={value} language={language} copyable={false} />
+          <HighlightedCode
+            code={value}
+            language={language}
+            copyable={false}
+            dataTestId={dataTestId}
+            ariaLabel={label}
+          />
         ) : (
           <textarea
+            data-testid={dataTestId ? `${dataTestId}-content` : undefined}
+            aria-label={label}
             value={value}
             readOnly
             placeholder={placeholder}
@@ -227,6 +237,8 @@ function ToolTextArea({
         )
       ) : (
         <textarea
+          data-testid={dataTestId ? `${dataTestId}-content` : undefined}
+          aria-label={label}
           value={value}
           onChange={onChange}
           placeholder={placeholder}
@@ -1000,6 +1012,7 @@ export default function DataGenerator() {
             placeholder="Generated data will appear here..."
             highlightOn={highlightOn}
             language="json"
+            dataTestId="data-generator-output"
           />
           {output && (
             <div style={{ marginTop: '12px' }}>

--- a/frontend/src/pages/HashGenerator/index.jsx
+++ b/frontend/src/pages/HashGenerator/index.jsx
@@ -63,6 +63,7 @@ function ToolPane({
   error,
   highlightOn,
   language = 'plaintext',
+  dataTestId,
 }) {
   const handleCopy = () => {
     if (value) navigator.clipboard.writeText(value);
@@ -145,9 +146,17 @@ function ToolPane({
       </div>
       {readOnly ? (
         highlightOn ? (
-          <HighlightedCode code={value} language={language} copyable={false} />
+          <HighlightedCode
+            code={value}
+            language={language}
+            copyable={false}
+            dataTestId={dataTestId}
+            ariaLabel={label}
+          />
         ) : (
           <textarea
+            data-testid={dataTestId ? `${dataTestId}-content` : undefined}
+            aria-label={label}
             value={value}
             readOnly
             placeholder={placeholder}
@@ -174,6 +183,8 @@ function ToolPane({
           language={language}
           highlight={highlightOn}
           placeholder={placeholder}
+          dataTestId={dataTestId}
+          ariaLabel={label}
         />
       )}
     </div>
@@ -338,6 +349,7 @@ export default function HashGenerator() {
             indicator="Source"
             indicatorColor="green"
             highlightOn={highlightOn}
+            dataTestId="hash-generator-input"
           />
           {isAll ? (
             <div
@@ -405,6 +417,7 @@ export default function HashGenerator() {
               indicatorColor="blue"
               error={!!error}
               highlightOn={highlightOn}
+              dataTestId="hash-generator-output"
             />
           )}
         </ToolSplitPane>

--- a/frontend/src/pages/JwtDebugger/index.jsx
+++ b/frontend/src/pages/JwtDebugger/index.jsx
@@ -51,6 +51,7 @@ function ToolTextArea({
   highlightOn,
   language = 'plaintext',
   style = {},
+  dataTestId,
 }) {
   const handleCopy = () => {
     if (value) navigator.clipboard.writeText(value);
@@ -121,9 +122,17 @@ function ToolTextArea({
       </div>
       {readOnly ? (
         highlightOn ? (
-          <HighlightedCode code={value} language={language} copyable={false} />
+          <HighlightedCode
+            code={value}
+            language={language}
+            copyable={false}
+            dataTestId={dataTestId}
+            ariaLabel={label}
+          />
         ) : (
           <textarea
+            data-testid={dataTestId ? `${dataTestId}-content` : undefined}
+            aria-label={label}
             value={value}
             readOnly
             placeholder={placeholder}
@@ -151,6 +160,8 @@ function ToolTextArea({
           language={language}
           highlight={highlightOn}
           placeholder={placeholder}
+          dataTestId={dataTestId}
+          ariaLabel={label}
         />
       )}
     </div>
@@ -561,6 +572,7 @@ export default function JwtDebugger() {
               onChange={(e) => setJwt(e.target.value)}
               placeholder="Paste encoded JWT here..."
               highlightOn={highlightOn}
+              dataTestId="jwt-decode-token"
             />
             <div
               style={{
@@ -622,6 +634,7 @@ export default function JwtDebugger() {
               placeholder="{ 'alg': 'HS256', 'typ': 'JWT' }"
               highlightOn={highlightOn}
               language="json"
+              dataTestId="jwt-decode-header"
             />
             <ToolTextArea
               label="Payload (Data)"
@@ -630,6 +643,7 @@ export default function JwtDebugger() {
               placeholder="{ 'sub': '1234567890', 'name': 'John Doe' }"
               highlightOn={highlightOn}
               language="json"
+              dataTestId="jwt-decode-payload"
             />
           </div>
         </ToolSplitPane>
@@ -643,6 +657,7 @@ export default function JwtDebugger() {
               placeholder='{"alg": "HS256", "typ": "JWT"}'
               highlightOn={highlightOn}
               language="json"
+              dataTestId="jwt-encode-header"
             />
             <ToolTextArea
               label="Payload (JSON)"
@@ -651,6 +666,7 @@ export default function JwtDebugger() {
               placeholder='{"sub": "1234567890", "name": "John Doe"}'
               highlightOn={highlightOn}
               language="json"
+              dataTestId="jwt-encode-payload"
             />
             <div
               style={{
@@ -697,6 +713,7 @@ export default function JwtDebugger() {
               readOnly
               placeholder="Encoded JWT will appear here..."
               highlightOn={highlightOn}
+              dataTestId="jwt-encode-token"
             />
             {error && <StatusMessage type="error">{error}</StatusMessage>}
           </div>

--- a/frontend/src/pages/TextDiffChecker/index.jsx
+++ b/frontend/src/pages/TextDiffChecker/index.jsx
@@ -625,6 +625,8 @@ export default function TextDiffChecker() {
                 onChange={(val) => setOriginal(val)}
                 language="plaintext"
                 placeholder="Paste original version here..."
+                dataTestId="text-diff-original"
+                ariaLabel="Original Text"
               />
             </div>
             <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
@@ -665,6 +667,8 @@ export default function TextDiffChecker() {
                 onChange={(val) => setModified(val)}
                 language="plaintext"
                 placeholder="Paste modified version here..."
+                dataTestId="text-diff-modified"
+                ariaLabel="Modified Text"
               />
             </div>
           </div>

--- a/frontend/src/pages/TextUtilities/index.jsx
+++ b/frontend/src/pages/TextUtilities/index.jsx
@@ -40,6 +40,7 @@ function ToolPane({
   indicatorColor,
   highlightOn,
   language = 'plaintext',
+  dataTestId,
 }) {
   const handleCopy = () => {
     if (value) navigator.clipboard.writeText(value);
@@ -112,9 +113,17 @@ function ToolPane({
       </div>
       {readOnly ? (
         highlightOn ? (
-          <HighlightedCode code={value} language={language} copyable={false} />
+          <HighlightedCode
+            code={value}
+            language={language}
+            copyable={false}
+            dataTestId={dataTestId}
+            ariaLabel={label}
+          />
         ) : (
           <textarea
+            data-testid={dataTestId ? `${dataTestId}-content` : undefined}
+            aria-label={label}
             value={value}
             readOnly
             placeholder={placeholder}
@@ -141,6 +150,8 @@ function ToolPane({
           language={language}
           highlight={highlightOn}
           placeholder={placeholder}
+          dataTestId={dataTestId}
+          ariaLabel={label}
         />
       )}
     </div>
@@ -351,6 +362,7 @@ export default function TextUtilities() {
           indicator="Source"
           indicatorColor="green"
           highlightOn={highlightOn}
+          dataTestId="text-utilities-input"
         />
         <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', overflow: 'auto' }}>
           <div style={{ flex: '0 0 40%', display: 'flex', flexDirection: 'column' }}>
@@ -362,6 +374,7 @@ export default function TextUtilities() {
               indicator="Output"
               indicatorColor="blue"
               highlightOn={highlightOn}
+              dataTestId="text-utilities-output"
             />
           </div>
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.3.1
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/stretchr/testify v1.11.1
-	github.com/wailsapp/wails/v3 v3.0.0-alpha.8.3
+	github.com/wailsapp/wails/v3 v3.0.0-alpha.88
 	golang.design/x/hotkey v0.4.1
 	golang.org/x/crypto v0.51.0
 	golang.org/x/net v0.54.0
@@ -30,6 +30,7 @@ require (
 	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
+	github.com/coder/websocket v1.8.14 // indirect
 	github.com/cyphar/filepath-securejoin v0.6.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/ebitengine/purego v0.9.1 // indirect
@@ -63,6 +64,7 @@ require (
 	github.com/ugorji/go/codec v1.3.1 // indirect
 	github.com/wailsapp/go-webview2 v1.0.18 // indirect
 	github.com/wailsapp/mimetype v1.4.1 // indirect
+	github.com/wailsapp/wails/webview2 v1.0.24 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
 	golang.org/x/arch v0.22.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.3.1
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/stretchr/testify v1.11.1
-	github.com/wailsapp/wails/v3 v3.0.0-alpha.88
+	github.com/wailsapp/wails/v3 v3.0.0-alpha.95
 	golang.design/x/hotkey v0.4.1
 	golang.org/x/crypto v0.51.0
 	golang.org/x/net v0.54.0

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
+github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
+github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVyciv8syjIpVE=
 github.com/cyphar/filepath-securejoin v0.6.1/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -132,6 +134,7 @@ github.com/lmittmann/tint v1.1.2 h1:2CQzrL6rslrsyjqLDwD11bZ5OpLBPU+g3G/r5LSfS8w=
 github.com/lmittmann/tint v1.1.2/go.mod h1:HIS3gSy7qNwGCj+5oRjAutErFBl4BzdQP6cJZ0NfMwE=
 github.com/matryer/is v1.4.0 h1:sosSmIWwkYITGrxZ25ULNDeKiMNzFSr4V/eqBQP0PeE=
 github.com/matryer/is v1.4.0/go.mod h1:8I/i5uYgLzgsgEloJE1U6xx5HkBQpAZvepWuujKwMRU=
+github.com/matryer/is v1.4.1 h1:55ehd8zaGABKLXQUe2awZ99BD/PTc2ls+KV/dXphgEQ=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
@@ -197,6 +200,10 @@ github.com/wailsapp/mimetype v1.4.1 h1:pQN9ycO7uo4vsUUuPeHEYoUkLVkaRntMnHJxVwYhw
 github.com/wailsapp/mimetype v1.4.1/go.mod h1:9aV5k31bBOv5z6u+QP8TltzvNGJPmNJD4XlAL3U+j3o=
 github.com/wailsapp/wails/v3 v3.0.0-alpha.8.3 h1:9aCL0IXD60A5iscQ/ps6f3ti3IlaoG6LQe0RZ9JkueU=
 github.com/wailsapp/wails/v3 v3.0.0-alpha.8.3/go.mod h1:9Ca1goy5oqxmy8Oetb8Tchkezcx4tK03DK+SqYByu5Y=
+github.com/wailsapp/wails/v3 v3.0.0-alpha.88 h1:ygKZGv0FxJfji2KCLZZE+BYDE/UHaW9Ca5c8UEFx7Iw=
+github.com/wailsapp/wails/v3 v3.0.0-alpha.88/go.mod h1:5exzAEkyvbCcdowFevzZf23SYEEvmf+pkx7gg1gOR0Q=
+github.com/wailsapp/wails/webview2 v1.0.24 h1:uULnjCSaRfMlU84mS3kjLgPsRosEOIusVK1nFOHZHzs=
+github.com/wailsapp/wails/webview2 v1.0.24/go.mod h1:sdf+s0nAdxlzVWf9SCxC15XaxnQPJeY+uU1Ucn3jHQM=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=

--- a/go.sum
+++ b/go.sum
@@ -202,6 +202,8 @@ github.com/wailsapp/wails/v3 v3.0.0-alpha.8.3 h1:9aCL0IXD60A5iscQ/ps6f3ti3IlaoG6
 github.com/wailsapp/wails/v3 v3.0.0-alpha.8.3/go.mod h1:9Ca1goy5oqxmy8Oetb8Tchkezcx4tK03DK+SqYByu5Y=
 github.com/wailsapp/wails/v3 v3.0.0-alpha.88 h1:ygKZGv0FxJfji2KCLZZE+BYDE/UHaW9Ca5c8UEFx7Iw=
 github.com/wailsapp/wails/v3 v3.0.0-alpha.88/go.mod h1:5exzAEkyvbCcdowFevzZf23SYEEvmf+pkx7gg1gOR0Q=
+github.com/wailsapp/wails/v3 v3.0.0-alpha.95 h1:Rve8djRSldn6381q2l8gw8XEnzPX/4So6VsRM6bc7Vs=
+github.com/wailsapp/wails/v3 v3.0.0-alpha.95/go.mod h1:3euiK0wb6vnXvxiHysRYYbukCa060bLSsfrvN7sZg4k=
 github.com/wailsapp/wails/webview2 v1.0.24 h1:uULnjCSaRfMlU84mS3kjLgPsRosEOIusVK1nFOHZHzs=
 github.com/wailsapp/wails/webview2 v1.0.24/go.mod h1:sdf+s0nAdxlzVWf9SCxC15XaxnQPJeY+uU1Ucn3jHQM=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=


### PR DESCRIPTION
## Summary
- add stable test/accessibility hooks to CodeMirror-backed editors and affected tool panes
- fix read-only highlighted output panes so they mount while empty and update when output arrives
- update end-user E2E specs to use shared editor helpers instead of raw textarea selectors
- add accessible Barcode layout toggle labeling and disable empty Data Generator copy icon

## Verification
- cd frontend && bun run format
- cd frontend && node_modules/@playwright/test/cli.js test e2e/codeEncoder.spec.js e2e/codeConverter.spec.js e2e/hashGenerator.spec.js e2e/codeEncrypter.spec.js e2e/textUtilities.spec.js e2e/textDiffChecker.spec.js e2e/jwtDebugger.spec.js e2e/codeFormatter.spec.js e2e/dataGenerator.spec.js e2e/barcodeGenerator.spec.js e2e/regExpTester.spec.js (138 passed)
- cd frontend && node_modules/@playwright/test/cli.js test (217 passed)
- cd frontend && node_modules/vitest/vitest.mjs run (31 passed)
- cd frontend && node_modules/vite/bin/vite.js build --mode production
- go test ./internal/... ./service/... ./pkg/...

## Known unrelated issue
- go test ./... still fails in cmd/testserver because cmd/testserver/main.go references service.NewConversionService, which is not part of this change.
