### PR TITLE
Add URL Inspector tool

### DIFF
--- a/frontend/e2e/every-page.spec.js
+++ b/frontend/e2e/every-page.spec.js
@@ -13,6 +13,7 @@ const TOOLS = [
   { slug: 'data-generator', name: 'Data Generator' },
   { slug: 'code-formatter', name: 'Code Formatter' },
   { slug: 'color-converter', name: 'Color Converter' },
+  { slug: 'url-inspector', name: 'URL Inspector' },
   { slug: 'cron', name: 'Cron' },
   { slug: 'regexp', name: 'RegExp' },
   { slug: 'diff', name: 'Diff' },

--- a/frontend/e2e/urlInspector.spec.js
+++ b/frontend/e2e/urlInspector.spec.js
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test';
+
+async function gotoUrlInspector(page) {
+  await page.goto('/tool/url-inspector');
+  await page.waitForLoadState('networkidle');
+}
+
+function builtUrlOutput(page) {
+  return page.locator('section').filter({ hasText: 'Built URL' }).locator('pre');
+}
+
+test.describe('URL Inspector', () => {
+  test('loads sample URL and rebuilds it', async ({ page }) => {
+    await gotoUrlInspector(page);
+
+    await expect(page.getByRole('heading', { name: 'URL Inspector' })).toBeVisible();
+    await expect(page.getByLabel('URL')).toHaveValue(
+      'https://example.com:8443/api/search?q=hello%20world&debug=true#results'
+    );
+    await expect(page.getByLabel('Scheme')).toHaveValue('https');
+    await expect(page.getByLabel('Host')).toHaveValue('example.com:8443');
+    await expect(page.getByLabel('Path')).toHaveValue('/api/search');
+    await expect(page.getByLabel('Hash')).toHaveValue('results');
+    await expect(builtUrlOutput(page)).toContainText(
+      'https://example.com:8443/api/search?q=hello+world&debug=true#results'
+    );
+  });
+
+  test('parses pasted URL and sorts query parameters', async ({ page }) => {
+    await gotoUrlInspector(page);
+
+    await page.getByLabel('URL').fill('https://example.test/docs?z=last&a=two&a=one#top%20section');
+
+    await expect(page.getByLabel('Host')).toHaveValue('example.test');
+    await expect(page.getByLabel('Path')).toHaveValue('/docs');
+    await expect(page.getByLabel('Hash')).toHaveValue('top section');
+
+    await page.getByRole('button', { name: 'Sort' }).click();
+
+    await expect(page.getByLabel('Query key').nth(0)).toHaveValue('a');
+    await expect(page.getByLabel('Query value').nth(0)).toHaveValue('one');
+    await expect(page.getByLabel('Query key').nth(1)).toHaveValue('a');
+    await expect(page.getByLabel('Query value').nth(1)).toHaveValue('two');
+    await expect(page.getByLabel('Query key').nth(2)).toHaveValue('z');
+    await expect(builtUrlOutput(page)).toContainText(
+      'https://example.test/docs?a=one&a=two&z=last#top%20section'
+    );
+  });
+
+  test('shows validation error for relative URL input', async ({ page }) => {
+    await gotoUrlInspector(page);
+
+    await page.getByLabel('URL').fill('/docs?query=true');
+
+    await expect(page.getByRole('alert')).toContainText('Enter an absolute URL');
+    await expect(builtUrlOutput(page)).toContainText(
+      'https://example.com:8443/api/search?q=hello+world&debug=true#results'
+    );
+  });
+
+  test('copy button writes rebuilt URL to clipboard', async ({ page, context }) => {
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+    await gotoUrlInspector(page);
+
+    await page.getByLabel('URL').fill('https://example.test/path?q=copy%20me');
+    await page.getByRole('button', { name: 'Copy' }).click();
+
+    const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clipboardText).toBe('https://example.test/path?q=copy+me');
+    await expect(page.getByRole('button', { name: 'Copied' })).toBeVisible();
+  });
+});

--- a/frontend/src/ToolRouter.jsx
+++ b/frontend/src/ToolRouter.jsx
@@ -17,6 +17,7 @@ import BarcodeGenerator from './pages/BarcodeGenerator';
 import DataGenerator from './pages/DataGenerator';
 import CodeFormatter from './pages/CodeFormatter';
 import ColorConverter from './pages/ColorConverter';
+import UrlInspector from './pages/UrlInspector';
 
 const toolComponents = {
   'code-encrypter': CodeEncrypter,
@@ -30,6 +31,7 @@ const toolComponents = {
   'data-generator': DataGenerator,
   'code-formatter': CodeFormatter,
   'color-converter': ColorConverter,
+  'url-inspector': UrlInspector,
   regexp: RegExpTester,
   cron: CronJobParser,
   diff: TextDiffChecker,

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -26,6 +26,7 @@ import {
   Code2,
   Timer,
   FileCode,
+  Link,
 } from 'lucide-react';
 import { ScrollArea } from './ui/scroll-area';
 
@@ -50,6 +51,7 @@ const TOOL_ICONS = {
   'data-generator': LayoutGrid,
   'code-formatter': Code2,
   'color-converter': Palette,
+  'url-inspector': Link,
   cron: Timer,
   regexp: Regex,
   diff: FileDiff,
@@ -150,6 +152,7 @@ export function Sidebar({ isVisible, onOpenSettings }) {
     { id: 'data-generator', name: 'Data Generator', category: 'Generator' },
     { id: 'code-formatter', name: 'Code Formatter', category: 'Developer' },
     { id: 'color-converter', name: 'Color Converter', category: 'Developer' },
+    { id: 'url-inspector', name: 'URL Inspector', category: 'Developer' },
     { id: 'cron', name: 'Cron Job Parser', category: 'Developer' },
     { id: 'regexp', name: 'RegExp Tester', category: 'Developer' },
     { id: 'diff', name: 'Text Diff', category: 'Text' },
@@ -366,6 +369,7 @@ export function Sidebar({ isVisible, onOpenSettings }) {
                         'cron',
                         'code-formatter',
                         'color-converter',
+                        'url-inspector',
                         'number-converter',
                         'datetime-converter',
                       ].includes(tool.id)

--- a/frontend/src/pages/UrlInspector/index.jsx
+++ b/frontend/src/pages/UrlInspector/index.jsx
@@ -1,0 +1,357 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Check, Copy, Plus, RefreshCw, SortAsc, Trash2 } from 'lucide-react';
+import { Button } from '../../components/ui/Button';
+import { buildUrl, parseUrlInput, sortQueryRows } from './urlUtils';
+
+const SAMPLE_URL = 'https://example.com:8443/api/search?q=hello%20world&debug=true#results';
+
+function Field({ label, value, onChange, placeholder }) {
+  return (
+    <label style={{ display: 'flex', flexDirection: 'column', gap: '6px', minWidth: 0 }}>
+      <span
+        style={{
+          fontSize: '11px',
+          fontWeight: 600,
+          color: 'var(--muted-foreground)',
+          textTransform: 'uppercase',
+          letterSpacing: '0.05em',
+        }}
+      >
+        {label}
+      </span>
+      <input
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        style={{
+          height: '36px',
+          width: '100%',
+          border: '1px solid var(--border)',
+          borderRadius: '6px',
+          backgroundColor: 'var(--card)',
+          color: 'var(--foreground)',
+          padding: '0 10px',
+          fontSize: '13px',
+          outline: 'none',
+          fontFamily: label === 'Path' ? "'Menlo', 'Monaco', 'Courier New', monospace" : 'inherit',
+        }}
+      />
+    </label>
+  );
+}
+
+function createRow() {
+  return { id: `param-${crypto.randomUUID()}`, key: '', value: '' };
+}
+
+export default function UrlInspector() {
+  const [inputUrl, setInputUrl] = useState(SAMPLE_URL);
+  const [parts, setParts] = useState({
+    scheme: 'https',
+    host: 'example.com:8443',
+    path: '/api/search',
+    hash: 'results',
+  });
+  const [queryRows, setQueryRows] = useState([
+    { id: 'q-0', key: 'q', value: 'hello world' },
+    { id: 'debug-1', key: 'debug', value: 'true' },
+  ]);
+  const [parseError, setParseError] = useState(null);
+  const [copied, setCopied] = useState(false);
+
+  const builtResult = useMemo(() => buildUrl({ ...parts, queryRows }), [parts, queryRows]);
+
+  useEffect(() => {
+    const result = parseUrlInput(inputUrl);
+    setParseError(result.error);
+    if (!result.error && result.parts) {
+      setParts(result.parts);
+      setQueryRows(result.queryRows.length > 0 ? result.queryRows : [createRow()]);
+    }
+  }, [inputUrl]);
+
+  const updatePart = (name, value) => {
+    setParts((current) => ({ ...current, [name]: value }));
+  };
+
+  const updateRow = (id, field, value) => {
+    setQueryRows((rows) => rows.map((row) => (row.id === id ? { ...row, [field]: value } : row)));
+  };
+
+  const removeRow = (id) => {
+    setQueryRows((rows) => rows.filter((row) => row.id !== id));
+  };
+
+  const copyBuiltUrl = async () => {
+    if (!builtResult.url) return;
+    await navigator.clipboard.writeText(builtResult.url);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  const transformValue = (id, transform) => {
+    setQueryRows((rows) =>
+      rows.map((row) => {
+        if (row.id !== id) return row;
+        try {
+          return { ...row, value: transform(row.value) };
+        } catch {
+          return row;
+        }
+      })
+    );
+  };
+
+  return (
+    <div
+      style={{
+        height: '100%',
+        overflow: 'auto',
+        padding: '24px',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '16px',
+      }}
+    >
+      <div>
+        <h2
+          style={{
+            fontSize: '24px',
+            fontWeight: 600,
+            color: 'var(--foreground)',
+            margin: 0,
+          }}
+        >
+          URL Inspector
+        </h2>
+        <p style={{ color: 'var(--muted-foreground)', margin: '4px 0 0' }}>
+          Parse, edit, sort, encode, and rebuild URLs.
+        </p>
+      </div>
+
+      <section
+        style={{
+          border: '1px solid var(--border)',
+          borderRadius: '8px',
+          backgroundColor: 'var(--card)',
+          padding: '16px',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '12px',
+        }}
+      >
+        <label style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+          <span
+            style={{
+              fontSize: '11px',
+              fontWeight: 600,
+              color: 'var(--muted-foreground)',
+              textTransform: 'uppercase',
+              letterSpacing: '0.05em',
+            }}
+          >
+            URL
+          </span>
+          <textarea
+            value={inputUrl}
+            onChange={(event) => setInputUrl(event.target.value)}
+            spellCheck={false}
+            style={{
+              minHeight: '78px',
+              resize: 'vertical',
+              border: '1px solid var(--border)',
+              borderRadius: '6px',
+              backgroundColor: 'var(--background)',
+              color: 'var(--foreground)',
+              padding: '12px',
+              fontSize: '13px',
+              outline: 'none',
+              fontFamily: "'Menlo', 'Monaco', 'Courier New', monospace",
+            }}
+          />
+        </label>
+        {parseError && (
+          <div
+            role="alert"
+            style={{
+              border: '1px solid var(--destructive)',
+              color: 'var(--destructive)',
+              borderRadius: '6px',
+              padding: '10px 12px',
+              fontSize: '13px',
+              backgroundColor: 'color-mix(in srgb, var(--destructive) 8%, transparent)',
+            }}
+          >
+            {parseError}
+          </div>
+        )}
+      </section>
+
+      <section
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))',
+          gap: '12px',
+        }}
+      >
+        <Field
+          label="Scheme"
+          value={parts.scheme}
+          onChange={(value) => updatePart('scheme', value)}
+        />
+        <Field label="Host" value={parts.host} onChange={(value) => updatePart('host', value)} />
+        <Field label="Path" value={parts.path} onChange={(value) => updatePart('path', value)} />
+        <Field label="Hash" value={parts.hash} onChange={(value) => updatePart('hash', value)} />
+      </section>
+
+      <section
+        style={{
+          border: '1px solid var(--border)',
+          borderRadius: '8px',
+          backgroundColor: 'var(--card)',
+          padding: '16px',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '12px',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: '8px',
+          }}
+        >
+          <h3 style={{ margin: 0, fontSize: '16px', fontWeight: 600 }}>Query Params</h3>
+          <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+            <Button variant="secondary" onClick={() => setQueryRows(sortQueryRows(queryRows))}>
+              <SortAsc size={14} /> Sort
+            </Button>
+            <Button
+              variant="secondary"
+              onClick={() => setQueryRows((rows) => [...rows, createRow()])}
+            >
+              <Plus size={14} /> Add
+            </Button>
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+          {queryRows.map((row) => (
+            <div
+              key={row.id}
+              style={{
+                display: 'grid',
+                gridTemplateColumns: 'minmax(120px, 0.8fr) minmax(160px, 1.2fr) auto',
+                gap: '8px',
+                alignItems: 'center',
+              }}
+            >
+              <input
+                aria-label="Query key"
+                value={row.key}
+                onChange={(event) => updateRow(row.id, 'key', event.target.value)}
+                placeholder="key"
+                style={{
+                  height: '34px',
+                  border: '1px solid var(--border)',
+                  borderRadius: '6px',
+                  backgroundColor: 'var(--background)',
+                  color: 'var(--foreground)',
+                  padding: '0 10px',
+                  minWidth: 0,
+                }}
+              />
+              <input
+                aria-label="Query value"
+                value={row.value}
+                onChange={(event) => updateRow(row.id, 'value', event.target.value)}
+                placeholder="value"
+                style={{
+                  height: '34px',
+                  border: '1px solid var(--border)',
+                  borderRadius: '6px',
+                  backgroundColor: 'var(--background)',
+                  color: 'var(--foreground)',
+                  padding: '0 10px',
+                  minWidth: 0,
+                }}
+              />
+              <div style={{ display: 'flex', gap: '6px' }}>
+                <Button
+                  title="Encode value"
+                  variant="outline"
+                  onClick={() => transformValue(row.id, encodeURIComponent)}
+                  style={{ width: '34px', height: '34px', padding: 0 }}
+                >
+                  %
+                </Button>
+                <Button
+                  title="Decode value"
+                  variant="outline"
+                  onClick={() => transformValue(row.id, decodeURIComponent)}
+                  style={{ width: '34px', height: '34px', padding: 0 }}
+                >
+                  <RefreshCw size={14} />
+                </Button>
+                <Button
+                  title="Remove param"
+                  variant="danger"
+                  onClick={() => removeRow(row.id)}
+                  style={{ width: '34px', height: '34px', padding: 0 }}
+                >
+                  <Trash2 size={14} />
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section
+        style={{
+          border: '1px solid var(--border)',
+          borderRadius: '8px',
+          backgroundColor: 'var(--card)',
+          padding: '16px',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '10px',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: '8px',
+          }}
+        >
+          <h3 style={{ margin: 0, fontSize: '16px', fontWeight: 600 }}>Built URL</h3>
+          <Button variant="secondary" onClick={copyBuiltUrl} disabled={!builtResult.url}>
+            {copied ? <Check size={14} /> : <Copy size={14} />}
+            {copied ? 'Copied' : 'Copy'}
+          </Button>
+        </div>
+        <pre
+          style={{
+            margin: 0,
+            minHeight: '54px',
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-all',
+            border: '1px solid var(--border)',
+            borderRadius: '6px',
+            backgroundColor: 'var(--background)',
+            color: builtResult.error ? 'var(--destructive)' : 'var(--foreground)',
+            padding: '12px',
+            fontSize: '13px',
+            fontFamily: "'Menlo', 'Monaco', 'Courier New', monospace",
+          }}
+        >
+          {builtResult.error || builtResult.url}
+        </pre>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/UrlInspector/urlUtils.js
+++ b/frontend/src/pages/UrlInspector/urlUtils.js
@@ -1,0 +1,79 @@
+const ABSOLUTE_URL_PATTERN = /^[a-z][a-z\d+.-]*:\/\//i;
+
+function rowId(key, index) {
+  const safeKey = key.trim().replace(/[^a-z0-9_-]+/gi, '-') || 'param';
+  return `${safeKey}-${index}`;
+}
+
+export function parseUrlInput(input) {
+  const rawInput = input.trim();
+
+  if (!rawInput) {
+    return { parts: null, queryRows: [], error: null };
+  }
+
+  if (!ABSOLUTE_URL_PATTERN.test(rawInput)) {
+    return {
+      parts: null,
+      queryRows: [],
+      error: 'Enter an absolute URL with a scheme, for example https://example.com.',
+    };
+  }
+
+  try {
+    const parsedUrl = new URL(rawInput);
+    const queryRows = Array.from(parsedUrl.searchParams.entries()).map(([key, value], index) => ({
+      id: rowId(key, index),
+      key,
+      value,
+    }));
+
+    return {
+      parts: {
+        scheme: parsedUrl.protocol.replace(':', ''),
+        host: parsedUrl.host,
+        path: parsedUrl.pathname,
+        hash: parsedUrl.hash ? decodeURIComponent(parsedUrl.hash.slice(1)) : '',
+      },
+      queryRows,
+      error: null,
+    };
+  } catch {
+    return {
+      parts: null,
+      queryRows: [],
+      error: 'Enter a valid absolute URL.',
+    };
+  }
+}
+
+export function buildUrl({ scheme, host, path, hash, queryRows }) {
+  const cleanScheme = scheme.trim().replace(/:$/, '');
+  const cleanHost = host.trim();
+
+  if (!cleanScheme || !cleanHost) {
+    return { url: '', error: 'Scheme and host are required.' };
+  }
+
+  try {
+    const builtUrl = new URL(`${cleanScheme}://${cleanHost}`);
+    builtUrl.pathname = path?.startsWith('/') ? path : `/${path || ''}`;
+
+    const params = new URLSearchParams();
+    queryRows.filter((row) => row.key.trim()).forEach((row) => params.append(row.key, row.value));
+    builtUrl.search = params.toString();
+    builtUrl.hash = hash || '';
+
+    return { url: builtUrl.toString(), error: null };
+  } catch {
+    return { url: '', error: 'URL parts could not be combined into a valid URL.' };
+  }
+}
+
+export function sortQueryRows(rows) {
+  return [...rows].sort((left, right) => {
+    const keyCompare = left.key.localeCompare(right.key);
+    if (keyCompare !== 0) return keyCompare;
+    return left.value.localeCompare(right.value);
+  });
+}

--- a/frontend/src/pages/UrlInspector/urlUtils.test.js
+++ b/frontend/src/pages/UrlInspector/urlUtils.test.js
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { buildUrl, parseUrlInput, sortQueryRows } from './urlUtils';
+
+describe('urlUtils', () => {
+  it('parses URL parts and repeated query params', () => {
+    const result = parseUrlInput(
+      'https://example.com:8443/api/search?q=hello%20world&q=again&empty=&flag#section'
+    );
+
+    expect(result.error).toBeNull();
+    expect(result.parts).toMatchObject({
+      scheme: 'https',
+      host: 'example.com:8443',
+      path: '/api/search',
+      hash: 'section',
+    });
+    expect(result.queryRows).toEqual([
+      { id: 'q-0', key: 'q', value: 'hello world' },
+      { id: 'q-1', key: 'q', value: 'again' },
+      { id: 'empty-2', key: 'empty', value: '' },
+      { id: 'flag-3', key: 'flag', value: '' },
+    ]);
+  });
+
+  it('builds a URL with encoded query params and hash', () => {
+    const result = buildUrl({
+      scheme: 'https',
+      host: 'example.com',
+      path: '/docs',
+      hash: 'top section',
+      queryRows: [
+        { id: 'a', key: 'q', value: 'hello world' },
+        { id: 'b', key: 'redirect', value: 'https://app.test/a?b=1' },
+      ],
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.url).toBe(
+      'https://example.com/docs?q=hello+world&redirect=https%3A%2F%2Fapp.test%2Fa%3Fb%3D1#top%20section'
+    );
+  });
+
+  it('sorts query rows by key then value without mutating the input', () => {
+    const rows = [
+      { id: '3', key: 'z', value: 'last' },
+      { id: '1', key: 'a', value: 'two' },
+      { id: '2', key: 'a', value: 'one' },
+    ];
+
+    expect(sortQueryRows(rows)).toEqual([
+      { id: '2', key: 'a', value: 'one' },
+      { id: '1', key: 'a', value: 'two' },
+      { id: '3', key: 'z', value: 'last' },
+    ]);
+    expect(rows[0].id).toBe('3');
+  });
+
+  it('returns a validation error for invalid URLs', () => {
+    const result = parseUrlInput('not a url');
+
+    expect(result.parts).toBeNull();
+    expect(result.queryRows).toEqual([]);
+    expect(result.error).toContain('Enter an absolute URL');
+  });
+});


### PR DESCRIPTION
## Summary
- add URL Inspector route/sidebar entry
- parse pasted absolute URLs into scheme, host, path, hash, and editable query rows
- rebuild/copy URLs with sorted and encoded/decoded query param controls
- add focused helper coverage for parse/build/sort/error behavior

Closes #104.

## Verification
- npm run test -- src/pages/UrlInspector/urlUtils.test.js
- npm run test
- npm run build
- curl -I http://127.0.0.1:5173/tool/url-inspector