### PR TITLE
ci: use Wails release workflow with SemVer tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: macOS Release
 on:
   push:
     tags:
-      - "macos/devtoolbox/v*"
+      - "v*.*.*"
   workflow_dispatch:
 
 permissions:
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   release:
-    uses: vuon9/gh-workflows/.github/workflows/macos-desktop-release.yml@khoa/macos-desktop-release-workflow
+    uses: vuon9/gh-workflows/.github/workflows/wails-macos-release.yml@main
     with:
       app-name: DevToolbox
       bundle-id: com.vuon9.devtoolbox

--- a/docs/MACOS_RELEASE.md
+++ b/docs/MACOS_RELEASE.md
@@ -6,6 +6,10 @@ This project ships macOS releases as a signed, notarized, and stapled
 The first signed release is intentionally macOS-only. Linux and Windows release
 artifacts are skipped until a later release pass.
 
+Release tags use the normal stable project SemVer format, for example `v0.10.0`.
+The packaging script embeds the tag version into the macOS app bundle as
+`CFBundleShortVersionString` and `CFBundleVersion`.
+
 ## Required GitHub Secrets
 
 Configure these repository secrets before running a release:
@@ -28,14 +32,15 @@ missing. Unsigned macOS release artifacts are not uploaded by the release job.
 On macOS runners, the release job:
 
 1. Builds a universal `DevToolbox.app`.
-2. Imports the Developer ID Application certificate into a temporary keychain.
-3. Signs the app with hardened runtime and timestamping.
-4. Verifies the signature with `codesign --verify`.
-5. Submits the app to Apple notarization through App Store Connect API keys.
-6. Staples and validates the app notarization ticket.
-7. Runs `spctl --assess --type execute`.
-8. Packages the stapled app into `DevToolbox-macos-universal.dmg`.
-9. Signs, notarizes, staples, and verifies the DMG.
+2. Embeds the SemVer tag into the app bundle version fields.
+3. Imports the Developer ID Application certificate into a temporary keychain.
+4. Signs the app with hardened runtime and timestamping.
+5. Verifies the signature with `codesign --verify`.
+6. Submits the app to Apple notarization through App Store Connect API keys.
+7. Staples and validates the app notarization ticket.
+8. Runs `spctl --assess --type execute`.
+9. Packages the stapled app into `DevToolbox-macos-universal.dmg`.
+10. Signs, notarizes, staples, and verifies the DMG.
 
 Mini owns Apple Developer certificate export, repository secret setup, and final
 local Gatekeeper verification for the released artifact.

--- a/scripts/package-macos-universal.sh
+++ b/scripts/package-macos-universal.sh
@@ -3,6 +3,16 @@ set -euo pipefail
 
 app_name="${APP_NAME:-DevToolbox}"
 bin_dir="${BIN_DIR:-bin}"
+app_version="${APP_VERSION:-}"
+
+if [[ -z "$app_version" && "${GITHUB_REF_TYPE:-}" == "tag" ]]; then
+  app_version="${GITHUB_REF_NAME#v}"
+fi
+
+if [[ -n "$app_version" && ! "$app_version" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+  echo "APP_VERSION must be stable SemVer without a leading v; got: $app_version" >&2
+  exit 1
+fi
 
 export GOOS=darwin
 export CGO_ENABLED=1
@@ -36,6 +46,10 @@ mkdir -p "$app_bundle/Contents/Resources"
 
 cp "$bin_dir/$app_name" "$app_bundle/Contents/MacOS/"
 cp build/darwin/Info.plist "$app_bundle/Contents/"
+if [[ -n "$app_version" ]]; then
+  /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $app_version" "$app_bundle/Contents/Info.plist"
+  /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $app_version" "$app_bundle/Contents/Info.plist"
+fi
 cp build/darwin/icons.icns "$app_bundle/Contents/Resources/"
 if [[ -f build/darwin/Assets.car ]]; then
   cp build/darwin/Assets.car "$app_bundle/Contents/Resources/"


### PR DESCRIPTION
## Summary
- point the DevToolbox macOS release wrapper at the merged reusable Wails workflow on `main`
- switch release tags from `macos/devtoolbox/v*` to stable SemVer tags like `v0.10.0`
- stamp the SemVer tag into the macOS app bundle version fields during packaging

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "yaml ok"'`\n- `bash -n scripts/package-macos-universal.sh`\n- PlistBuddy smoke test stamped `0.10.0` into `CFBundleShortVersionString` and `CFBundleVersion`\n- SemVer derivation smoke test returned `0.10.0` from `GITHUB_REF_NAME=v0.10.0`\n- `go test $(go list ./... | grep -v '/cmd/testserver$')`\n\n## Known Existing Failure\n- `go test ./...` still fails in `cmd/testserver`: `undefined: service.NewConversionService`. This branch does not touch Go service/testserver code.