### PR TITLE
ci: support prerelease macOS builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
   # Allow manual trigger
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,4 +22,5 @@ jobs:
       artifact-name: devtoolbox-macos-release-${{ github.run_id }}
       go-version-file: go.mod
       runner-label: macos-26
+      github-release-prerelease: ${{ contains(github.ref_name, '-') }}
     secrets: inherit

--- a/docs/MACOS_RELEASE.md
+++ b/docs/MACOS_RELEASE.md
@@ -6,9 +6,12 @@ This project ships macOS releases as a signed, notarized, and stapled
 The first signed release is intentionally macOS-only. Linux and Windows release
 artifacts are skipped until a later release pass.
 
-Release tags use the normal stable project SemVer format, for example `v0.10.0`.
-The packaging script embeds the tag version into the macOS app bundle as
-`CFBundleShortVersionString` and `CFBundleVersion`.
+Release tags use normal project SemVer. Stable releases use tags such as
+`v0.10.0`; prereleases use tags such as `v0.10.0-rc.1`. The packaging script
+embeds the stable base version into the macOS app bundle as
+`CFBundleShortVersionString` and `CFBundleVersion`, so a prerelease tag like
+`v0.10.0-rc.1` embeds `0.10.0` in the app bundle and marks the GitHub Release
+as a prerelease.
 
 ## Required GitHub Secrets
 

--- a/scripts/package-macos-universal.sh
+++ b/scripts/package-macos-universal.sh
@@ -4,13 +4,22 @@ set -euo pipefail
 app_name="${APP_NAME:-DevToolbox}"
 bin_dir="${BIN_DIR:-bin}"
 app_version="${APP_VERSION:-}"
+tag_version=""
 
-if [[ -z "$app_version" && "${GITHUB_REF_TYPE:-}" == "tag" ]]; then
-  app_version="${GITHUB_REF_NAME#v}"
+if [[ "${GITHUB_REF_TYPE:-}" == "tag" ]]; then
+  tag_version="${GITHUB_REF_NAME#v}"
+  if [[ ! "$tag_version" =~ ^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+    echo "Release tag must be stable or prerelease SemVer with a leading v; got: ${GITHUB_REF_NAME:-}" >&2
+    exit 1
+  fi
+fi
+
+if [[ -z "$app_version" && -n "$tag_version" ]]; then
+  app_version="${tag_version%%-*}"
 fi
 
 if [[ -n "$app_version" && ! "$app_version" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
-  echo "APP_VERSION must be stable SemVer without a leading v; got: $app_version" >&2
+  echo "APP_VERSION must be stable SemVer without a leading v because Apple bundle versions do not include prerelease labels; got: $app_version" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- opt CI into Node 24 JavaScript actions to clear the cache restore deprecation warning
- mark GitHub Releases as prereleases when the tag contains a prerelease suffix
- accept prerelease SemVer tags like `v0.10.0-rc.1` while embedding the stable base version in the macOS app bundle

## Verification
- `ruby -e 'require "yaml"; %w[.github/workflows/ci.yml .github/workflows/release.yml].each { |path| YAML.load_file(path); puts "yaml ok #{path}" }'`\n- `bash -n scripts/package-macos-universal.sh`\n- prerelease tag derivation smoke test: `v0.10.0-rc.1` -> `0.10.0`\n\n## Known Existing Failure\n- `go test ./...` still fails in `cmd/testserver`: `undefined: service.NewConversionService`. The GitHub CI backend job only tests `./internal/...` and passed on main before this branch.