### PR TITLE
ci: avoid setup-go cache deprecation warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,6 @@ on:
   # Allow manual trigger
   workflow_dispatch:
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   build:
     name: Build
@@ -29,8 +26,6 @@ jobs:
         with:
           go-version: "1.25.0"
           check-latest: true
-          cache: true
-          cache-dependency-path: go.sum
 
       - name: Cache APT packages
         uses: awalsh128/cache-apt-pkgs-action@latest
@@ -83,8 +78,6 @@ jobs:
         with:
           go-version: "1.25.0"
           check-latest: true
-          cache: true
-          cache-dependency-path: go.sum
 
       - name: Run Go Tests
         run: |
@@ -130,8 +123,6 @@ jobs:
         with:
           go-version: "1.25.0"
           check-latest: true
-          cache: true
-          cache-dependency-path: go.sum
 
       - name: Install system deps (Wails CGO)
         run: |
@@ -159,8 +150,6 @@ jobs:
         with:
           go-version: "1.25.0"
           check-latest: true
-          cache: true
-          cache-dependency-path: go.sum
 
       - name: Cache APT packages
         uses: awalsh128/cache-apt-pkgs-action@latest


### PR DESCRIPTION
## Summary
- remove setup-go built-in caching so CI no longer invokes the deprecated Node 20 `actions/cache/restore@v4` helper
- keep the explicit Bun dependency cache on `actions/cache@v5.0.5`

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml ok"'`\n- `rg -n "cache: true|cache-dependency-path|FORCE_JAVASCRIPT_ACTIONS_TO_NODE24|actions/cache" .github/workflows/ci.yml` shows only explicit `actions/cache@v5.0.5` usages